### PR TITLE
feat(kyc): transactions export

### DIFF
--- a/Fetching
+++ b/Fetching
@@ -1,0 +1,3 @@
+
+# Bloc and Commit Conventions
+ documentation...

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -661,5 +661,15 @@
     "previewWithdrawal": "Preview Withdrawal",
     "createNewAddress": "Create New Address",
     "searchAddresses": "Search addresses",
-    "chart": "Chart"
+    "chart": "Chart",
+    "transactionExport": "Export Transactions",
+    "transactionExportUserInfoTitle": "Transaction Export - Your Information",
+    "transactionExportFullName": "Full Name",
+    "transactionExportEmail": "Email Address",
+    "transactionExportContinue": "Continue",
+    "transactionExportSelectTxTitle": "Select Transactions to Export",
+    "transactionExportPreviewTitle": "Preview Export",
+    "transactionExportCompleteTitle": "Export Complete",
+    "transactionExportDone": "Done",
+    "transactionExportExportButton": "Export"
 }

--- a/lib/bloc/transaction_export/transaction_export_cubit.dart
+++ b/lib/bloc/transaction_export/transaction_export_cubit.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:web_dex/services/file_loader/file_loader.dart';
+
+part 'transaction_export_state.dart';
+
+class TransactionExportCubit extends Cubit<TransactionExportState> {
+  TransactionExportCubit() : super(const TransactionExportState());
+
+  void setUserInfo(
+      {required String name, required String email, required String address}) {
+    emit(state.copyWith(name: name, email: email, address: address));
+  }
+
+  void nextStep() => emit(state.copyWith(step: state.step + 1));
+
+  void previousStep() => emit(state.copyWith(step: state.step - 1));
+
+  void toggleTransaction(Transaction tx) {
+    final current = List<Transaction>.from(state.selected);
+    if (current.contains(tx)) {
+      current.remove(tx);
+    } else {
+      current.add(tx);
+    }
+    emit(state.copyWith(selected: current));
+  }
+
+  Future<void> export() async {
+    emit(state.copyWith(isExporting: true));
+    final fileLoader = FileLoader.fromPlatform();
+    final data = {
+      'name': state.name,
+      'email': state.email,
+      'address': state.address,
+      'exportedAt': DateTime.now().toIso8601String(),
+      'transactions': state.selected
+          .map((e) => {
+                'tx_hash': e.txHash,
+                'asset': e.assetId.id,
+                'timestamp': e.timestamp.toIso8601String(),
+                'amount': e.balanceChanges.totalAmount.toString(),
+              })
+          .toList(),
+    };
+    await fileLoader.save(
+      fileName: 'transactions_export',
+      data: jsonEncode(data),
+      type: LoadFileType.text,
+    );
+    emit(state.copyWith(isExporting: false, step: 3));
+  }
+}

--- a/lib/bloc/transaction_export/transaction_export_state.dart
+++ b/lib/bloc/transaction_export/transaction_export_state.dart
@@ -1,0 +1,37 @@
+part of 'transaction_export_cubit.dart';
+
+class TransactionExportState {
+  const TransactionExportState({
+    this.step = 0,
+    this.name = '',
+    this.email = '',
+    this.address = '',
+    this.selected = const [],
+    this.isExporting = false,
+  });
+
+  final int step;
+  final String name;
+  final String email;
+  final String address;
+  final List<Transaction> selected;
+  final bool isExporting;
+
+  TransactionExportState copyWith({
+    int? step,
+    String? name,
+    String? email,
+    String? address,
+    List<Transaction>? selected,
+    bool? isExporting,
+  }) {
+    return TransactionExportState(
+      step: step ?? this.step,
+      name: name ?? this.name,
+      email: email ?? this.email,
+      address: address ?? this.address,
+      selected: selected ?? this.selected,
+      isExporting: isExporting ?? this.isExporting,
+    );
+  }
+}

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  LocaleKeys {
+abstract class LocaleKeys {
   static const plsActivateKmd = 'plsActivateKmd';
   static const rewardClaiming = 'rewardClaiming';
   static const noKmdAddress = 'noKmdAddress';
@@ -106,39 +106,50 @@ abstract class  LocaleKeys {
   static const seedPhrase = 'seedPhrase';
   static const assetNumber = 'assetNumber';
   static const clipBoard = 'clipBoard';
-  static const walletsManagerCreateWalletButton = 'walletsManagerCreateWalletButton';
-  static const walletsManagerImportWalletButton = 'walletsManagerImportWalletButton';
-  static const walletsManagerStepBuilderCreationWalletError = 'walletsManagerStepBuilderCreationWalletError';
+  static const walletsManagerCreateWalletButton =
+      'walletsManagerCreateWalletButton';
+  static const walletsManagerImportWalletButton =
+      'walletsManagerImportWalletButton';
+  static const walletsManagerStepBuilderCreationWalletError =
+      'walletsManagerStepBuilderCreationWalletError';
   static const walletCreationTitle = 'walletCreationTitle';
   static const walletImportTitle = 'walletImportTitle';
   static const walletImportByFileTitle = 'walletImportByFileTitle';
-  static const walletImportCreatePasswordTitle = 'walletImportCreatePasswordTitle';
+  static const walletImportCreatePasswordTitle =
+      'walletImportCreatePasswordTitle';
   static const walletImportByFileDescription = 'walletImportByFileDescription';
   static const walletLogInTitle = 'walletLogInTitle';
   static const walletCreationNameHint = 'walletCreationNameHint';
   static const walletCreationPasswordHint = 'walletCreationPasswordHint';
-  static const walletCreationConfirmPasswordHint = 'walletCreationConfirmPasswordHint';
+  static const walletCreationConfirmPasswordHint =
+      'walletCreationConfirmPasswordHint';
   static const walletCreationConfirmPassword = 'walletCreationConfirmPassword';
   static const walletCreationUploadFile = 'walletCreationUploadFile';
   static const walletCreationEmptySeedError = 'walletCreationEmptySeedError';
   static const walletCreationExistNameError = 'walletCreationExistNameError';
   static const walletCreationNameLengthError = 'walletCreationNameLengthError';
-  static const walletCreationFormatPasswordError = 'walletCreationFormatPasswordError';
-  static const walletCreationConfirmPasswordError = 'walletCreationConfirmPasswordError';
+  static const walletCreationFormatPasswordError =
+      'walletCreationFormatPasswordError';
+  static const walletCreationConfirmPasswordError =
+      'walletCreationConfirmPasswordError';
   static const incorrectPassword = 'incorrectPassword';
   static const importSeedEnterSeedPhraseHint = 'importSeedEnterSeedPhraseHint';
   static const passphraseCheckingTitle = 'passphraseCheckingTitle';
   static const passphraseCheckingDescription = 'passphraseCheckingDescription';
   static const passphraseCheckingEnterWord = 'passphraseCheckingEnterWord';
-  static const passphraseCheckingEnterWordHint = 'passphraseCheckingEnterWordHint';
+  static const passphraseCheckingEnterWordHint =
+      'passphraseCheckingEnterWordHint';
   static const back = 'back';
   static const settingsMenuGeneral = 'settingsMenuGeneral';
   static const settingsMenuLanguage = 'settingsMenuLanguage';
   static const settingsMenuSecurity = 'settingsMenuSecurity';
   static const settingsMenuAbout = 'settingsMenuAbout';
-  static const seedPhraseSettingControlsViewSeed = 'seedPhraseSettingControlsViewSeed';
-  static const seedPhraseSettingControlsDownloadSeed = 'seedPhraseSettingControlsDownloadSeed';
-  static const debugSettingsResetActivatedCoins = 'debugSettingsResetActivatedCoins';
+  static const seedPhraseSettingControlsViewSeed =
+      'seedPhraseSettingControlsViewSeed';
+  static const seedPhraseSettingControlsDownloadSeed =
+      'seedPhraseSettingControlsDownloadSeed';
+  static const debugSettingsResetActivatedCoins =
+      'debugSettingsResetActivatedCoins';
   static const debugSettingsDownloadButton = 'debugSettingsDownloadButton';
   static const or = 'or';
   static const passwordTitle = 'passwordTitle';
@@ -148,16 +159,19 @@ abstract class  LocaleKeys {
   static const changePasswordSpan1 = 'changePasswordSpan1';
   static const updatePassword = 'updatePassword';
   static const passwordHasChanged = 'passwordHasChanged';
-  static const confirmationForShowingSeedPhraseTitle = 'confirmationForShowingSeedPhraseTitle';
+  static const confirmationForShowingSeedPhraseTitle =
+      'confirmationForShowingSeedPhraseTitle';
   static const saveAndRemember = 'saveAndRemember';
   static const seedPhraseShowingTitle = 'seedPhraseShowingTitle';
   static const seedPhraseShowingWarning = 'seedPhraseShowingWarning';
   static const seedPhraseShowingShowPhrase = 'seedPhraseShowingShowPhrase';
   static const seedPhraseShowingCopySeed = 'seedPhraseShowingCopySeed';
-  static const seedPhraseShowingSavedPhraseButton = 'seedPhraseShowingSavedPhraseButton';
+  static const seedPhraseShowingSavedPhraseButton =
+      'seedPhraseShowingSavedPhraseButton';
   static const seedAccessSpan1 = 'seedAccessSpan1';
   static const backupSeedNotificationTitle = 'backupSeedNotificationTitle';
-  static const backupSeedNotificationDescription = 'backupSeedNotificationDescription';
+  static const backupSeedNotificationDescription =
+      'backupSeedNotificationDescription';
   static const backupSeedNotificationButton = 'backupSeedNotificationButton';
   static const swapConfirmationTitle = 'swapConfirmationTitle';
   static const swapConfirmationYouReceive = 'swapConfirmationYouReceive';
@@ -165,41 +179,54 @@ abstract class  LocaleKeys {
   static const tradingDetailsTitleFailed = 'tradingDetailsTitleFailed';
   static const tradingDetailsTitleCompleted = 'tradingDetailsTitleCompleted';
   static const tradingDetailsTitleInProgress = 'tradingDetailsTitleInProgress';
-  static const tradingDetailsTitleOrderMatching = 'tradingDetailsTitleOrderMatching';
+  static const tradingDetailsTitleOrderMatching =
+      'tradingDetailsTitleOrderMatching';
   static const tradingDetailsTotalSpentTime = 'tradingDetailsTotalSpentTime';
-  static const tradingDetailsTotalSpentTimeWithHours = 'tradingDetailsTotalSpentTimeWithHours';
+  static const tradingDetailsTotalSpentTimeWithHours =
+      'tradingDetailsTotalSpentTimeWithHours';
   static const swapRecoverButtonTitle = 'swapRecoverButtonTitle';
   static const swapRecoverButtonText = 'swapRecoverButtonText';
   static const swapRecoverButtonErrorMessage = 'swapRecoverButtonErrorMessage';
-  static const swapRecoverButtonSuccessMessage = 'swapRecoverButtonSuccessMessage';
+  static const swapRecoverButtonSuccessMessage =
+      'swapRecoverButtonSuccessMessage';
   static const swapProgressStatusFailed = 'swapProgressStatusFailed';
   static const swapDetailsStepStatusFailed = 'swapDetailsStepStatusFailed';
   static const disclaimerAcceptEulaCheckbox = 'disclaimerAcceptEulaCheckbox';
-  static const disclaimerAcceptTermsAndConditionsCheckbox = 'disclaimerAcceptTermsAndConditionsCheckbox';
+  static const disclaimerAcceptTermsAndConditionsCheckbox =
+      'disclaimerAcceptTermsAndConditionsCheckbox';
   static const disclaimerAcceptDescription = 'disclaimerAcceptDescription';
-  static const swapDetailsStepStatusInProcess = 'swapDetailsStepStatusInProcess';
-  static const swapDetailsStepStatusTimeSpent = 'swapDetailsStepStatusTimeSpent';
+  static const swapDetailsStepStatusInProcess =
+      'swapDetailsStepStatusInProcess';
+  static const swapDetailsStepStatusTimeSpent =
+      'swapDetailsStepStatusTimeSpent';
   static const milliseconds = 'milliseconds';
   static const seconds = 'seconds';
   static const minutes = 'minutes';
   static const hours = 'hours';
-  static const coinAddressDetailsNotificationTitle = 'coinAddressDetailsNotificationTitle';
-  static const coinAddressDetailsNotificationDescription = 'coinAddressDetailsNotificationDescription';
+  static const coinAddressDetailsNotificationTitle =
+      'coinAddressDetailsNotificationTitle';
+  static const coinAddressDetailsNotificationDescription =
+      'coinAddressDetailsNotificationDescription';
   static const swapFeeDetailsPaidFromBalance = 'swapFeeDetailsPaidFromBalance';
   static const swapFeeDetailsSendCoinTxFee = 'swapFeeDetailsSendCoinTxFee';
-  static const swapFeeDetailsReceiveCoinTxFee = 'swapFeeDetailsReceiveCoinTxFee';
+  static const swapFeeDetailsReceiveCoinTxFee =
+      'swapFeeDetailsReceiveCoinTxFee';
   static const swapFeeDetailsTradingFee = 'swapFeeDetailsTradingFee';
-  static const swapFeeDetailsSendTradingFeeTxFee = 'swapFeeDetailsSendTradingFeeTxFee';
+  static const swapFeeDetailsSendTradingFeeTxFee =
+      'swapFeeDetailsSendTradingFeeTxFee';
   static const swapFeeDetailsNone = 'swapFeeDetailsNone';
-  static const swapFeeDetailsPaidFromReceivedVolume = 'swapFeeDetailsPaidFromReceivedVolume';
+  static const swapFeeDetailsPaidFromReceivedVolume =
+      'swapFeeDetailsPaidFromReceivedVolume';
   static const logoutPopupTitle = 'logoutPopupTitle';
-  static const logoutPopupDescriptionWalletOnly = 'logoutPopupDescriptionWalletOnly';
+  static const logoutPopupDescriptionWalletOnly =
+      'logoutPopupDescriptionWalletOnly';
   static const logoutPopupDescription = 'logoutPopupDescription';
   static const transactionDetailsTitle = 'transactionDetailsTitle';
   static const customSeedWarningText = 'customSeedWarningText';
   static const customSeedIUnderstand = 'customSeedIUnderstand';
   static const walletCreationBip39SeedError = 'walletCreationBip39SeedError';
-  static const walletCreationHdBip39SeedError = 'walletCreationHdBip39SeedError';
+  static const walletCreationHdBip39SeedError =
+      'walletCreationHdBip39SeedError';
   static const walletPageNoSuchAsset = 'walletPageNoSuchAsset';
   static const swapCoin = 'swapCoin';
   static const fiatBalance = 'fiatBalance';
@@ -269,7 +296,8 @@ abstract class  LocaleKeys {
   static const sell = 'sell';
   static const buy = 'buy';
   static const changingWalletPassword = 'changingWalletPassword';
-  static const changingWalletPasswordDescription = 'changingWalletPasswordDescription';
+  static const changingWalletPasswordDescription =
+      'changingWalletPasswordDescription';
   static const dark = 'dark';
   static const darkMode = 'darkMode';
   static const light = 'light';
@@ -292,7 +320,8 @@ abstract class  LocaleKeys {
   static const email = 'email';
   static const emailValidatorError = 'emailValidatorError';
   static const feedbackValidatorEmptyError = 'feedbackValidatorEmptyError';
-  static const feedbackValidatorMaxLengthError = 'feedbackValidatorMaxLengthError';
+  static const feedbackValidatorMaxLengthError =
+      'feedbackValidatorMaxLengthError';
   static const yourFeedback = 'yourFeedback';
   static const sendFeedback = 'sendFeedback';
   static const sendFeedbackError = 'sendFeedbackError';
@@ -341,7 +370,8 @@ abstract class  LocaleKeys {
   static const noSenderAddress = 'noSenderAddress';
   static const confirmOnTrezor = 'confirmOnTrezor';
   static const alphaVersionWarningTitle = 'alphaVersionWarningTitle';
-  static const alphaVersionWarningDescription = 'alphaVersionWarningDescription';
+  static const alphaVersionWarningDescription =
+      'alphaVersionWarningDescription';
   static const sendToAnalytics = 'sendToAnalytics';
   static const backToWallet = 'backToWallet';
   static const backToDex = 'backToDex';
@@ -387,13 +417,16 @@ abstract class  LocaleKeys {
   static const bridgeMaxSendAmountError = 'bridgeMaxSendAmountError';
   static const bridgeMinOrderAmountError = 'bridgeMinOrderAmountError';
   static const bridgeMaxOrderAmountError = 'bridgeMaxOrderAmountError';
-  static const bridgeInsufficientBalanceError = 'bridgeInsufficientBalanceError';
+  static const bridgeInsufficientBalanceError =
+      'bridgeInsufficientBalanceError';
   static const lowTradeVolumeError = 'lowTradeVolumeError';
   static const bridgeSelectReceiveCoinError = 'bridgeSelectReceiveCoinError';
   static const withdrawNoParentCoinError = 'withdrawNoParentCoinError';
   static const withdrawTopUpBalanceError = 'withdrawTopUpBalanceError';
-  static const withdrawNotEnoughBalanceForGasError = 'withdrawNotEnoughBalanceForGasError';
-  static const withdrawNotSufficientBalanceError = 'withdrawNotSufficientBalanceError';
+  static const withdrawNotEnoughBalanceForGasError =
+      'withdrawNotEnoughBalanceForGasError';
+  static const withdrawNotSufficientBalanceError =
+      'withdrawNotSufficientBalanceError';
   static const withdrawZeroBalanceError = 'withdrawZeroBalanceError';
   static const withdrawAmountTooLowError = 'withdrawAmountTooLowError';
   static const withdrawNoSuchCoinError = 'withdrawNoSuchCoinError';
@@ -465,8 +498,10 @@ abstract class  LocaleKeys {
   static const availableForSwaps = 'availableForSwaps';
   static const swapNow = 'swapNow';
   static const passphrase = 'passphrase';
-  static const enterPassphraseHiddenWalletTitle = 'enterPassphraseHiddenWalletTitle';
-  static const enterPassphraseHiddenWalletDescription = 'enterPassphraseHiddenWalletDescription';
+  static const enterPassphraseHiddenWalletTitle =
+      'enterPassphraseHiddenWalletTitle';
+  static const enterPassphraseHiddenWalletDescription =
+      'enterPassphraseHiddenWalletDescription';
   static const skip = 'skip';
   static const activateToSeeFunds = 'activateToSeeFunds';
   static const allowCustomFee = 'allowCustomFee';
@@ -529,8 +564,10 @@ abstract class  LocaleKeys {
   static const collectibles = 'collectibles';
   static const sendingProcess = 'sendingProcess';
   static const ercStandardDisclaimer = 'ercStandardDisclaimer';
-  static const nftReceiveNonSwapAddressWarning = 'nftReceiveNonSwapAddressWarning';
-  static const nftReceiveNonSwapWalletDetails = 'nftReceiveNonSwapWalletDetails';
+  static const nftReceiveNonSwapAddressWarning =
+      'nftReceiveNonSwapAddressWarning';
+  static const nftReceiveNonSwapWalletDetails =
+      'nftReceiveNonSwapWalletDetails';
   static const nftMainLoggedOut = 'nftMainLoggedOut';
   static const confirmLogoutOnAnotherTab = 'confirmLogoutOnAnotherTab';
   static const refreshList = 'refreshList';
@@ -544,8 +581,10 @@ abstract class  LocaleKeys {
   static const noWalletsAvailable = 'noWalletsAvailable';
   static const selectWalletToReset = 'selectWalletToReset';
   static const qrScannerTitle = 'qrScannerTitle';
-  static const qrScannerErrorControllerUninitialized = 'qrScannerErrorControllerUninitialized';
-  static const qrScannerErrorPermissionDenied = 'qrScannerErrorPermissionDenied';
+  static const qrScannerErrorControllerUninitialized =
+      'qrScannerErrorControllerUninitialized';
+  static const qrScannerErrorPermissionDenied =
+      'qrScannerErrorPermissionDenied';
   static const qrScannerErrorGenericError = 'qrScannerErrorGenericError';
   static const qrScannerErrorTitle = 'qrScannerErrorTitle';
   static const spend = 'spend';
@@ -589,7 +628,8 @@ abstract class  LocaleKeys {
   static const fiatPaymentInProgressMessage = 'fiatPaymentInProgressMessage';
   static const pleaseWait = 'pleaseWait';
   static const bitrefillPaymentSuccessfull = 'bitrefillPaymentSuccessfull';
-  static const bitrefillPaymentSuccessfullInstruction = 'bitrefillPaymentSuccessfullInstruction';
+  static const bitrefillPaymentSuccessfullInstruction =
+      'bitrefillPaymentSuccessfullInstruction';
   static const tradingBot = 'tradingBot';
   static const margin = 'margin';
   static const updateInterval = 'updateInterval';
@@ -659,5 +699,17 @@ abstract class  LocaleKeys {
   static const createNewAddress = 'createNewAddress';
   static const searchAddresses = 'searchAddresses';
   static const chart = 'chart';
-
+  static const transactionExport = 'transactionExport';
+  static const transactionExportUserInfoTitle =
+      'transactionExportUserInfoTitle';
+  static const transactionExportFullName = 'transactionExportFullName';
+  static const transactionExportEmail = 'transactionExportEmail';
+  static const transactionExportContinue = 'transactionExportContinue';
+  static const transactionExportSelectTxTitle =
+      'transactionExportSelectTxTitle';
+  static const transactionExportPreviewTitle = 'transactionExportPreviewTitle';
+  static const transactionExportCompleteTitle =
+      'transactionExportCompleteTitle';
+  static const transactionExportDone = 'transactionExportDone';
+  static const transactionExportExportButton = 'transactionExportExportButton';
 }

--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -11,6 +11,7 @@ import 'package:web_dex/views/settings/widgets/general_settings/settings_manage_
 import 'package:web_dex/views/settings/widgets/general_settings/settings_reset_activated_coins.dart';
 import 'package:web_dex/views/settings/widgets/general_settings/settings_theme_switcher.dart';
 import 'package:web_dex/views/settings/widgets/general_settings/show_swap_data.dart';
+import 'package:web_dex/views/settings/widgets/general_settings/settings_transaction_export.dart';
 
 class GeneralSettings extends StatelessWidget {
   const GeneralSettings({Key? key}) : super(key: key);
@@ -37,6 +38,10 @@ class GeneralSettings extends StatelessWidget {
         const SizedBox(height: 25),
         const HiddenWithWallet(
           child: SettingsResetActivatedCoins(),
+        ),
+        const SizedBox(height: 25),
+        const HiddenWithoutWallet(
+          child: SettingsTransactionExport(),
         ),
         const SizedBox(height: 25),
         const HiddenWithoutWallet(

--- a/lib/views/settings/widgets/general_settings/settings_transaction_export.dart
+++ b/lib/views/settings/widgets/general_settings/settings_transaction_export.dart
@@ -1,0 +1,33 @@
+import 'package:app_theme/app_theme.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/views/wallet/transaction_export/transaction_export_page.dart';
+
+class SettingsTransactionExport extends StatelessWidget {
+  const SettingsTransactionExport({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return UiBorderButton(
+      width: 160,
+      height: 32,
+      borderWidth: 1,
+      borderColor: theme.custom.specificButtonBorderColor,
+      backgroundColor: theme.custom.specificButtonBackgroundColor,
+      fontWeight: FontWeight.w500,
+      text: LocaleKeys.transactionExport.tr(),
+      icon: Icon(
+        Icons.file_download,
+        color: Theme.of(context).textTheme.bodyMedium?.color,
+        size: 18,
+      ),
+      onPressed: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const TransactionExportPage()),
+        );
+      },
+    );
+  }
+}

--- a/lib/views/wallet/transaction_export/transaction_export_page.dart
+++ b/lib/views/wallet/transaction_export/transaction_export_page.dart
@@ -1,0 +1,182 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/transaction_export/transaction_export_cubit.dart';
+import 'package:web_dex/bloc/transaction_history/transaction_history_bloc.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class TransactionExportPage extends StatelessWidget {
+  const TransactionExportPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => TransactionExportCubit(),
+      child: const _TransactionExportView(),
+    );
+  }
+}
+
+class _TransactionExportView extends StatefulWidget {
+  const _TransactionExportView();
+
+  @override
+  State<_TransactionExportView> createState() => _TransactionExportViewState();
+}
+
+class _TransactionExportViewState extends State<_TransactionExportView> {
+  final _nameCtrl = TextEditingController();
+  final _emailCtrl = TextEditingController();
+  final _addressCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<TransactionExportCubit, TransactionExportState>(
+      builder: (context, state) {
+        switch (state.step) {
+          case 0:
+            return _buildUserInfo(context);
+          case 1:
+            return _buildSelectTransactions(context);
+          case 2:
+            return _buildPreview(context);
+          default:
+            return _buildComplete(context);
+        }
+      },
+    );
+  }
+
+  Widget _buildUserInfo(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(LocaleKeys.transactionExport.tr())),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Text(LocaleKeys.transactionExportUserInfoTitle.tr(),
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _nameCtrl,
+              decoration: InputDecoration(
+                labelText: LocaleKeys.transactionExportFullName.tr(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _emailCtrl,
+              decoration: InputDecoration(
+                labelText: LocaleKeys.transactionExportEmail.tr(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _addressCtrl,
+              decoration: const InputDecoration(labelText: 'Address'),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () {
+                context.read<TransactionExportCubit>().setUserInfo(
+                      name: _nameCtrl.text,
+                      email: _emailCtrl.text,
+                      address: _addressCtrl.text,
+                    );
+                context.read<TransactionExportCubit>().nextStep();
+              },
+              child: Text(LocaleKeys.transactionExportContinue.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSelectTransactions(BuildContext context) {
+    final txs = context.watch<TransactionHistoryBloc>().state.transactions;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(LocaleKeys.transactionExportSelectTxTitle.tr()),
+        leading: BackButton(
+          onPressed: () =>
+              context.read<TransactionExportCubit>().previousStep(),
+        ),
+      ),
+      body: ListView.builder(
+        itemCount: txs.length,
+        itemBuilder: (context, index) {
+          final tx = txs[index];
+          final selected = context
+              .read<TransactionExportCubit>()
+              .state
+              .selected
+              .contains(tx);
+          return CheckboxListTile(
+            value: selected,
+            title: Text(tx.txHash ?? tx.id),
+            subtitle: Text(tx.timestamp.toString()),
+            onChanged: (_) {
+              context.read<TransactionExportCubit>().toggleTransaction(tx);
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: context.read<TransactionExportCubit>().state.selected.isEmpty
+            ? null
+            : () => context.read<TransactionExportCubit>().nextStep(),
+        child: const Icon(Icons.arrow_forward),
+      ),
+    );
+  }
+
+  Widget _buildPreview(BuildContext context) {
+    final state = context.watch<TransactionExportCubit>().state;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(LocaleKeys.transactionExportPreviewTitle.tr()),
+        leading: BackButton(
+          onPressed: () =>
+              context.read<TransactionExportCubit>().previousStep(),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Name: ${state.name}'),
+            Text('Email: ${state.email}'),
+            Text('Address: ${state.address}'),
+            const SizedBox(height: 16),
+            Text('${state.selected.length} transactions selected'),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: state.isExporting
+                  ? null
+                  : () => context.read<TransactionExportCubit>().export(),
+              child: state.isExporting
+                  ? const CircularProgressIndicator()
+                  : Text(LocaleKeys.transactionExportExportButton.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComplete(BuildContext context) {
+    return Scaffold(
+      appBar:
+          AppBar(title: Text(LocaleKeys.transactionExportCompleteTitle.tr())),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(LocaleKeys.transactionExportDone.tr()),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TransactionExport cubit and state
- implement TransactionExportPage with basic steps
- add settings button to open transaction export
- add translations for the new flow
- use SDK `Transaction` model for export

## Testing
- `dart format lib/bloc/transaction_export/transaction_export_cubit.dart lib/bloc/transaction_export/transaction_export_state.dart lib/views/settings/widgets/general_settings/general_settings.dart lib/views/settings/widgets/general_settings/settings_transaction_export.dart lib/views/wallet/transaction_export/transaction_export_page.dart lib/generated/codegen_loader.g.dart`
- `flutter analyze` *(fails: 517 issues, mostly existing)*