### PR TITLE
fix: update address validation flow

### DIFF
--- a/lib/bloc/withdraw_form/withdraw_form_bloc.dart
+++ b/lib/bloc/withdraw_form/withdraw_form_bloc.dart
@@ -112,6 +112,16 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
     try {
       final trimmedAddress = event.address.trim();
 
+      // Optimistically update the address and clear previous errors so the UI
+      // reflects user input immediately. Validation results will update the
+      // state again when available.
+      emit(
+        state.copyWith(
+          recipientAddress: trimmedAddress,
+          recipientAddressError: () => null,
+        ),
+      );
+
       // First check if it's an EVM address that needs conversion
       if (state.asset.protocol is Erc20Protocol &&
           _isValidEthAddressFormat(trimmedAddress) &&


### PR DESCRIPTION
## Summary
- clear any previous address errors when input changes so that the preview button becomes available immediately

## Testing
- `dart format lib/bloc/withdraw_form/withdraw_form_bloc.dart`
- `dart format .`
- `flutter analyze`
- `flutter pub get --enforce-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_6862a56980908326a5056c8d43974430