### PR TITLE
fix: correct disable warning placeholders

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -231,7 +231,7 @@
     "clickAssetToAddHint": "No assets selected",
     "clickAssetToRemoveHint": "Select assets to remove",
     "defaultCoinDisableWarning": "You can't disable {}, it is a default coin",
-    "parentCoinDisableWarning": "Disabling {0} will also disable its tokens: {1}. Continue?",
+    "parentCoinDisableWarning": "Disabling {} will also disable its tokens: {}. Continue?",
     "supportFrequentlyQuestionSpan": "Frequently asked questions",
     "support": "Support",
     "supportInfoTitle1": "Do you store my private keys?",


### PR DESCRIPTION
## Summary
- ensure parent coin deactivation warning inserts coin and token names properly

## Testing
- `flutter analyze`
- `flutter pub get --offline`


------
https://chatgpt.com/codex/tasks/task_e_6865586f267c83268f7b2223cfb70e60