### PR TITLE
fix(wallet): open assets tab when tapping balance

### DIFF
--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -101,11 +101,7 @@ class _WalletOverviewState extends State<WalletOverview> {
                   totalBalance: totalBalance,
                   changeAmount: totalChange24h,
                   changePercentage: percentageChange24h,
-                  onTap: () {
-                    final formattedValue = NumberFormat.currency(symbol: '\$')
-                        .format(totalBalance);
-                    copyToClipBoard(context, formattedValue);
-                  },
+                  onTap: widget.onAssetsPressed,
                 );
               },
             ),
@@ -114,11 +110,7 @@ class _WalletOverviewState extends State<WalletOverview> {
               key: const Key('overview-current-value'),
               caption: Text(LocaleKeys.yourBalance.tr()),
               value: totalBalance,
-              onPressed: () {
-                final formattedValue =
-                    NumberFormat.currency(symbol: '\$').format(totalBalance);
-                copyToClipBoard(context, formattedValue);
-              },
+              onPressed: widget.onAssetsPressed,
               trendWidget:
                   BlocBuilder<PortfolioGrowthBloc, PortfolioGrowthState>(
                 builder: (context, state) {


### PR DESCRIPTION
## Summary
- route balance taps to the Assets tab

## Testing
- `flutter pub get --enforce-lockfile`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_686f9584462c8326a3d5ba755cc61b18