### PR TITLE
fix: reference correct trading disabled locale

### DIFF
--- a/lib/views/bridge/bridge_confirmation.dart
+++ b/lib/views/bridge/bridge_confirmation.dart
@@ -411,7 +411,7 @@ class _ConfirmButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final tradingStatusState = context.watch<TradingStatusBloc>().state;
     final tradingEnabled = tradingStatusState.isEnabled;
-    
+
     return Flexible(
         child: BlocSelector<BridgeBloc, BridgeState, bool>(
             selector: (state) => state.inProgress,
@@ -424,7 +424,7 @@ class _ConfirmButton extends StatelessWidget {
                   prefix: inProgress ? const _ProgressIndicator() : null,
                   text: tradingEnabled
                       ? LocaleKeys.confirm.tr()
-                      : LocaleKeys.tradingDisabledTooltip.tr(),
+                      : LocaleKeys.tradingDisabled.tr(),
                   onPressed: inProgress || !tradingEnabled ? null : onPressed,
                 ),
               );

--- a/lib/views/bridge/bridge_exchange_form.dart
+++ b/lib/views/bridge/bridge_exchange_form.dart
@@ -142,7 +142,7 @@ class _ExchangeButton extends StatelessWidget {
                       prefix: inProgress ? const _Spinner() : null,
                       text: tradingEnabled
                           ? LocaleKeys.exchange.tr()
-                          : LocaleKeys.tradingDisabledTooltip.tr(),
+                          : LocaleKeys.tradingDisabled.tr(),
                       onPressed: isDisabled || !tradingEnabled
                           ? null
                           : () => _onPressed(context),

--- a/lib/views/dex/simple/confirm/maker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/maker_order_confirmation.dart
@@ -148,7 +148,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
           onPressed: _inProgress || !tradingEnabled ? null : _startSwap,
           text: tradingEnabled
               ? LocaleKeys.confirm.tr()
-              : LocaleKeys.tradingDisabledTooltip.tr()),
+              : LocaleKeys.tradingDisabled.tr()),
     );
   }
 

--- a/lib/views/dex/simple/confirm/taker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/taker_order_confirmation.dart
@@ -157,7 +157,7 @@ class _TakerOrderConfirmationState extends State<TakerOrderConfirmation> {
                   : () => _startSwap(context),
               text: tradingEnabled
                   ? LocaleKeys.confirm.tr()
-                  : LocaleKeys.tradingDisabledTooltip.tr()),
+                  : LocaleKeys.tradingDisabled.tr()),
         );
       },
     );

--- a/lib/views/dex/simple/form/maker/maker_form_trade_button.dart
+++ b/lib/views/dex/simple/form/maker/maker_form_trade_button.dart
@@ -40,7 +40,7 @@ class MakerFormTradeButton extends StatelessWidget {
                 key: const Key('make-order-button'),
                 text: isTradingEnabled
                     ? LocaleKeys.makeOrder.tr()
-                    : LocaleKeys.tradingDisabledTooltip.tr(),
+                    : LocaleKeys.tradingDisabled.tr(),
                 prefix: inProgress
                     ? Padding(
                         padding: const EdgeInsets.only(right: 4),

--- a/lib/views/dex/simple/form/taker/taker_form_content.dart
+++ b/lib/views/dex/simple/form/taker/taker_form_content.dart
@@ -141,7 +141,7 @@ class TradeButton extends StatelessWidget {
                 key: const Key('take-order-button'),
                 text: isTradingEnabled
                     ? LocaleKeys.swapNow.tr()
-                    : LocaleKeys.tradingDisabledTooltip.tr(),
+                    : LocaleKeys.tradingDisabled.tr(),
                 prefix: inProgress ? const TradeButtonSpinner() : null,
                 onPressed: disabled || !isTradingEnabled
                     ? null

--- a/lib/views/market_maker_bot/add_market_maker_bot_trade_button.dart
+++ b/lib/views/market_maker_bot/add_market_maker_bot_trade_button.dart
@@ -30,7 +30,7 @@ class AddMarketMakerBotTradeButton extends StatelessWidget {
             key: const Key('make-order-button'),
             text: tradingEnabled
                 ? LocaleKeys.makeOrder.tr()
-                : LocaleKeys.tradingDisabledTooltip.tr(),
+                : LocaleKeys.tradingDisabled.tr(),
             onPressed: !enabled || !tradingEnabled ? null : () => onPressed(),
             height: 40,
           ),

--- a/lib/views/market_maker_bot/market_maker_bot_confirmation_form.dart
+++ b/lib/views/market_maker_bot/market_maker_bot_confirmation_form.dart
@@ -164,7 +164,7 @@ class SwapActionButtons extends StatelessWidget {
             onPressed: !tradingEnabled ? null : onCreateOrder,
             text: tradingEnabled
                 ? LocaleKeys.confirm.tr()
-                : LocaleKeys.tradingDisabledTooltip.tr(),
+                : LocaleKeys.tradingDisabled.tr(),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- use `LocaleKeys.tradingDisabled.tr()` for button titles when trading is disabled

## Testing
- `flutter pub get --offline`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68711a062e5c8326a3ee05cd50d88dfc