### PR TITLE
feat(analytics): record trade durations

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -344,6 +344,7 @@ analyticsRepo.logEvent(
     amount: 0.1,
     fee: 0.001,
     walletType: 'hd_wallet',
+    durationMs: 1234,
   ),
 );
 
@@ -354,6 +355,7 @@ analyticsRepo.logEvent(
     toAsset: 'KMD',
     failStage: 'order_matching',
     walletType: 'hd_wallet',
+    durationMs: 500,
   ),
 );
 ```

--- a/lib/analytics/analytics_factory.dart
+++ b/lib/analytics/analytics_factory.dart
@@ -231,12 +231,14 @@ class AnalyticsEvents {
     required String toChain,
     required String asset,
     required double amount,
+    required int durationMs,
   }) {
     return BridgeSuccessEvent(
       fromChain: fromChain,
       toChain: toChain,
       asset: asset,
       amount: amount,
+      durationMs: durationMs,
     );
   }
 
@@ -245,11 +247,13 @@ class AnalyticsEvents {
     required String fromChain,
     required String toChain,
     required String failError,
+    required int durationMs,
   }) {
     return BridgeFailureEvent(
       fromChain: fromChain,
       toChain: toChain,
       failError: failError,
+      durationMs: durationMs,
     );
   }
 
@@ -482,6 +486,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
     required this.toChain,
     required this.asset,
     required this.amount,
+    required this.durationMs,
   });
 
   @override
@@ -491,6 +496,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
   final String toChain;
   final String asset;
   final double amount;
+  final int durationMs;
 
   @override
   JsonMap get parameters => {
@@ -498,6 +504,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
         'to_chain': toChain,
         'asset': asset,
         'amount': amount,
+        'duration_ms': durationMs,
       };
 }
 
@@ -506,6 +513,7 @@ class BridgeFailureEvent extends AnalyticsEventData {
     required this.fromChain,
     required this.toChain,
     required this.failError,
+    required this.durationMs,
   });
 
   @override
@@ -514,12 +522,14 @@ class BridgeFailureEvent extends AnalyticsEventData {
   final String fromChain;
   final String toChain;
   final String failError;
+  final int durationMs;
 
   @override
   JsonMap get parameters => {
         'from_chain': fromChain,
         'to_chain': toChain,
         'fail_error': failError,
+        'duration_ms': durationMs,
       };
 }
 

--- a/lib/analytics/events/cross_chain_events.dart
+++ b/lib/analytics/events/cross_chain_events.dart
@@ -55,6 +55,7 @@ class BridgeSucceededEventData implements AnalyticsEventData {
     required this.asset,
     required this.amount,
     required this.walletType,
+    required this.durationMs,
   });
 
   final String fromChain;
@@ -62,6 +63,7 @@ class BridgeSucceededEventData implements AnalyticsEventData {
   final String asset;
   final double amount;
   final String walletType;
+  final int durationMs;
 
   @override
   String get name => 'bridge_success';
@@ -73,6 +75,7 @@ class BridgeSucceededEventData implements AnalyticsEventData {
         'asset': asset,
         'amount': amount,
         'wallet_type': walletType,
+        'duration_ms': durationMs,
       };
 }
 
@@ -84,6 +87,7 @@ class AnalyticsBridgeSucceededEvent extends AnalyticsSendDataEvent {
     required String asset,
     required double amount,
     required String walletType,
+    required int durationMs,
   }) : super(
           BridgeSucceededEventData(
             fromChain: fromChain,
@@ -91,6 +95,7 @@ class AnalyticsBridgeSucceededEvent extends AnalyticsSendDataEvent {
             asset: asset,
             amount: amount,
             walletType: walletType,
+            durationMs: durationMs,
           ),
         );
 }
@@ -103,12 +108,14 @@ class BridgeFailedEventData implements AnalyticsEventData {
     required this.toChain,
     required this.failError,
     required this.walletType,
+    required this.durationMs,
   });
 
   final String fromChain;
   final String toChain;
   final String failError;
   final String walletType;
+  final int durationMs;
 
   @override
   String get name => 'bridge_failure';
@@ -119,6 +126,7 @@ class BridgeFailedEventData implements AnalyticsEventData {
         'to_chain': toChain,
         'fail_error': failError,
         'wallet_type': walletType,
+        'duration_ms': durationMs,
       };
 }
 
@@ -129,12 +137,14 @@ class AnalyticsBridgeFailedEvent extends AnalyticsSendDataEvent {
     required String toChain,
     required String failError,
     required String walletType,
+    required int durationMs,
   }) : super(
           BridgeFailedEventData(
             fromChain: fromChain,
             toChain: toChain,
             failError: failError,
             walletType: walletType,
+            durationMs: durationMs,
           ),
         );
 }

--- a/lib/analytics/events/transaction_events.dart
+++ b/lib/analytics/events/transaction_events.dart
@@ -200,6 +200,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
     required this.amount,
     required this.fee,
     required this.walletType,
+    required this.durationMs,
   });
 
   final String fromAsset;
@@ -207,6 +208,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
   final double amount;
   final double fee;
   final String walletType;
+  final int durationMs;
 
   @override
   String get name => 'swap_success';
@@ -218,6 +220,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
         'amount': amount,
         'fee': fee,
         'wallet_type': walletType,
+        'duration_ms': durationMs,
       };
 }
 
@@ -229,12 +232,14 @@ class AnalyticsSwapSucceededEvent extends AnalyticsSendDataEvent {
     required double amount,
     required double fee,
     required String walletType,
+    required int durationMs,
   }) : super(SwapSucceededEventData(
           fromAsset: fromAsset,
           toAsset: toAsset,
           amount: amount,
           fee: fee,
           walletType: walletType,
+          durationMs: durationMs,
         ));
 }
 
@@ -250,12 +255,14 @@ class SwapFailedEventData implements AnalyticsEventData {
     required this.toAsset,
     required this.failStage,
     required this.walletType,
+    required this.durationMs,
   });
 
   final String fromAsset;
   final String toAsset;
   final String failStage;
   final String walletType;
+  final int durationMs;
 
   @override
   String get name => 'swap_failure';
@@ -266,6 +273,7 @@ class SwapFailedEventData implements AnalyticsEventData {
         'to_asset': toAsset,
         'fail_stage': failStage,
         'wallet_type': walletType,
+        'duration_ms': durationMs,
       };
 }
 
@@ -276,10 +284,12 @@ class AnalyticsSwapFailedEvent extends AnalyticsSendDataEvent {
     required String toAsset,
     required String failStage,
     required String walletType,
+    required int durationMs,
   }) : super(SwapFailedEventData(
           fromAsset: fromAsset,
           toAsset: toAsset,
           failStage: failStage,
           walletType: walletType,
+          durationMs: durationMs,
         ));
 }

--- a/lib/analytics/required_analytics_events.csv
+++ b/lib/analytics/required_analytics_events.csv
@@ -16,11 +16,11 @@ Send flow started,send_initiated,Transactions,"asset_symbol, network, amount","T
 On-chain send completed,send_success,Transactions,"asset_symbol, network, amount","Successful sends, volume, avg size",High (v0.9.0),FALSE,Send confirmation,Fire after a transaction broadcast succeeds.
 Send failed / cancelled,send_failure,Transactions,"asset_symbol, network, fail_reason","Error hotspots, UX / network issues",High (v0.9.0),FALSE,Send error handling,Emit when send flow fails or is cancelled.
 Swap order submitted,swap_initiated,Trading (DEX),"from_asset, to_asset, networks","DEX funnel start, pair demand",High (v0.9.0),FALSE,Swap order submit,Dispatch when atomic swap order created.
-Atomic swap succeeded,swap_success,Trading (DEX),"from_asset, to_asset, amount, fee","Trading volume, fee revenue",High (v0.9.0),FALSE,Swap completion,Send on successful atomic swap completion.
-Swap failed,swap_failure,Trading (DEX),"from_asset, to_asset, fail_stage","Liquidity gaps, tech/UX blockers",High (v0.9.0),FALSE,Swap error,Log when swap fails at any stage.
+Atomic swap succeeded,swap_success,Trading (DEX),"from_asset, to_asset, amount, fee, duration_ms","Trading volume, fee revenue",High (v0.9.0),FALSE,Swap completion,Send on successful atomic swap completion.
+Swap failed,swap_failure,Trading (DEX),"from_asset, to_asset, fail_stage, duration_ms","Liquidity gaps, tech/UX blockers",High (v0.9.0),FALSE,Swap error,Log when swap fails at any stage.
 Bridge transfer started,bridge_initiated,Cross-Chain,"from_chain, to_chain, asset","Bridge demand, chain pairs",Medium (v0.9.1),FALSE,Bridge transfer start,Emit when cross-chain bridge initiated.
-Bridge completed,bridge_success,Cross-Chain,"from_chain, to_chain, asset, amount","Cross-chain volume, success rate",Medium (v0.9.1),FALSE,Bridge completion,Send when bridge transfer succeeds.
-Bridge failed,bridge_failure,Cross-Chain,"from_chain, to_chain, fail_error","Reliability issues, risk analysis",Medium (v0.9.1),FALSE,Bridge error,Fire when bridge transfer fails.
+Bridge completed,bridge_success,Cross-Chain,"from_chain, to_chain, asset, amount, duration_ms","Cross-chain volume, success rate",Medium (v0.9.1),FALSE,Bridge completion,Send when bridge transfer succeeds.
+Bridge failed,bridge_failure,Cross-Chain,"from_chain, to_chain, fail_error, duration_ms","Reliability issues, risk analysis",Medium (v0.9.1),FALSE,Bridge error,Fire when bridge transfer fails.
 NFT gallery opened (measure load perf),nft_gallery_opened,NFT Wallet,"nft_count, load_time_ms","NFT engagement, gallery performance",Medium (v0.9.1),FALSE,NFT gallery screen,Record load time and count when gallery opened.
 NFT send flow started,nft_transfer_initiated,NFT Wallet,"collection_name, token_id, hd_type","NFT tx funnel start, collection popularity",Medium (v0.9.1),FALSE,NFT send screen,Trigger when user opens NFT transfer flow.
 NFT sent successfully,nft_transfer_success,NFT Wallet,"collection_name, token_id, fee, hd_type","NFT volume, user confidence",Medium (v0.9.1),FALSE,NFT send confirmation,Log when NFT transfer completes successfully.

--- a/lib/bloc/bridge_form/bridge_bloc.dart
+++ b/lib/bloc/bridge_form/bridge_bloc.dart
@@ -521,6 +521,7 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
     BridgeStartSwap event,
     Emitter<BridgeState> emit,
   ) async {
+    final Stopwatch stopwatch = Stopwatch()..start();
     final sellCoin = state.sellCoin;
     final bestOrder = state.bestOrder;
     if (sellCoin != null && bestOrder != null) {
@@ -546,6 +547,7 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
       price: state.bestOrder!.price,
       orderType: SellBuyOrderType.fillOrKill,
     ));
+    stopwatch.stop();
 
     final String? uuid = response.result?.uuid;
 
@@ -560,6 +562,7 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
           asset: state.sellCoin!.abbr,
           amount: state.sellAmount?.toDouble() ?? 0.0,
           walletType: walletType,
+          durationMs: stopwatch.elapsedMilliseconds,
         ),
       );
     } else {
@@ -573,6 +576,7 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
           toChain: buyCoin?.protocolType ?? '',
           failError: error,
           walletType: walletType,
+          durationMs: stopwatch.elapsedMilliseconds,
         ),
       );
       add(BridgeSetError(DexFormError(error: error)));

--- a/lib/views/dex/entity_details/trading_details.dart
+++ b/lib/views/dex/entity_details/trading_details.dart
@@ -146,6 +146,10 @@ class _TradingDetailsState extends State<TradingDetails> {
             break;
           }
         }
+        final durationMs = swapStatus.events.isNotEmpty
+            ? swapStatus.events.last.timestamp -
+                swapStatus.events.first.timestamp
+            : 0;
         context.read<AnalyticsBloc>().logEvent(
               SwapSucceededEventData(
                 fromAsset: fromAsset,
@@ -153,6 +157,7 @@ class _TradingDetailsState extends State<TradingDetails> {
                 amount: swapStatus.sellAmount.toDouble(),
                 fee: fee,
                 walletType: walletType ?? 'unknown',
+                durationMs: durationMs,
               ),
             );
 
@@ -167,17 +172,23 @@ class _TradingDetailsState extends State<TradingDetails> {
                   toChain: toChain,
                   asset: fromAsset,
                   amount: swapStatus.sellAmount.toDouble(),
+                  durationMs: durationMs,
                 ),
               );
         }
       } else if (swapStatus.isFailed && !_loggedFailure) {
         _loggedFailure = true;
+        final durationMs = swapStatus.events.isNotEmpty
+            ? swapStatus.events.last.timestamp -
+                swapStatus.events.first.timestamp
+            : 0;
         context.read<AnalyticsBloc>().logEvent(
               SwapFailedEventData(
                 fromAsset: fromAsset,
                 toAsset: toAsset,
                 failStage: swapStatus.status.name,
                 walletType: walletType ?? 'unknown',
+                durationMs: durationMs,
               ),
             );
 
@@ -191,6 +202,7 @@ class _TradingDetailsState extends State<TradingDetails> {
                   fromChain: fromChain,
                   toChain: toChain,
                   failError: swapStatus.status.name,
+                  durationMs: durationMs,
                 ),
               );
         }

--- a/lib/views/dex/simple/confirm/maker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/maker_order_confirmation.dart
@@ -310,6 +310,8 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
       _inProgress = true;
     });
 
+    final Stopwatch stopwatch = Stopwatch()..start();
+
     final authBloc = context.read<AuthBloc>();
     final walletType =
         authBloc.state.currentUser?.wallet.config.type.name ?? '';
@@ -328,6 +330,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
         );
 
     final TextError? error = await makerFormBloc.makeOrder();
+    stopwatch.stop();
 
     final tradingEntitiesBloc =
         // ignore: use_build_context_synchronously
@@ -346,6 +349,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
               toAsset: buyCoin,
               failStage: 'order_submission',
               walletType: walletType,
+              durationMs: stopwatch.elapsedMilliseconds,
             ),
           );
       setState(() => _errorMessage = error.error);
@@ -359,6 +363,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
             amount: makerFormBloc.sellAmount!.toDouble(),
             fee: 0, // Fee data not available
             walletType: walletType,
+            durationMs: stopwatch.elapsedMilliseconds,
           ),
         );
     makerFormBloc.clear();


### PR DESCRIPTION
## Summary
- capture execution duration for trading success & failure events
- include durations in bridge analytics events
- log durations in maker form, bridge bloc and trading details
- document new analytics parameters

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6875147df478832682b28157236f7158