### PR TITLE
feat(theme): update colors and layout

### DIFF
--- a/app_theme/lib/src/common/theme_custom_base.dart
+++ b/app_theme/lib/src/common/theme_custom_base.dart
@@ -182,8 +182,8 @@ class CoinsManagerTheme {
         const Color.fromRGBO(242, 242, 242, 1),
     this.filtersPopupShadow = const BoxShadow(
       offset: Offset(0, 0),
-      blurRadius: 13,
-      color: Color.fromRGBO(0, 0, 0, 0.06),
+      blurRadius: 8,
+      color: Color.fromRGBO(0, 0, 0, 0.04),
     ),
     this.filterPopupItemBorderColor = const Color.fromRGBO(136, 146, 235, 1),
     this.listHeaderBorderColor = const Color.fromRGBO(234, 234, 234, 1),

--- a/app_theme/lib/src/dark/theme_custom_dark.dart
+++ b/app_theme/lib/src/dark/theme_custom_dark.dart
@@ -47,21 +47,21 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   @override
   final Color fiatAmountColor = const Color.fromRGBO(168, 177, 185, 1);
   @override
-  final Color headerFloatBoxColor = const Color.fromRGBO(98, 121, 233, 1);
+  final Color headerFloatBoxColor = const Color(0xFF00D4AA);
   @override
-  final Color headerIconColor = const Color.fromRGBO(255, 255, 255, 1);
+  final Color headerIconColor = const Color(0xFF00D4AA);
   @override
   final Color buttonColorDefault = const Color.fromRGBO(23, 29, 48, 1);
 
   @override
-  final Color buttonColorDefaultHover = const Color.fromRGBO(76, 128, 233, 1);
+  final Color buttonColorDefaultHover = const Color(0xFF00D4AA);
   @override
   final Color buttonTextColorDefaultHover =
       const Color.fromRGBO(245, 249, 255, 1);
   @override
   final Color noColor = Colors.transparent;
   @override
-  final Color increaseColor = const Color.fromRGBO(0, 195, 170, 1);
+  final Color increaseColor = const Color(0xFF00D4AA);
   @override
   final Color decreaseColor = const Color.fromRGBO(229, 33, 103, 1);
   @override
@@ -92,7 +92,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   @override
   final Color defaultGradientButtonTextColor = Colors.white;
   @override
-  final Color defaultCheckboxColor = const Color.fromRGBO(81, 121, 233, 1);
+  final Color defaultCheckboxColor = const Color(0xFF00D4AA);
   @override
   final Gradient defaultSwitchColor = const LinearGradient(
     stops: [0, 93],
@@ -110,8 +110,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   @override
   final Color rewardBoxShadowColor = const Color.fromRGBO(0, 0, 0, 0.1);
   @override
-  final Color defaultBorderButtonBorder =
-      const Color.fromRGBO(136, 146, 235, 1);
+  final Color defaultBorderButtonBorder = const Color(0xFF00D4AA);
   @override
   final Color defaultBorderButtonBackground =
       const Color.fromRGBO(22, 25, 39, 1);
@@ -187,7 +186,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   @override
   final Color progressBarColor = const Color.fromRGBO(69, 96, 120, 0.33);
   @override
-  final Color progressBarPassedColor = const Color.fromRGBO(137, 147, 236, 1);
+  final Color progressBarPassedColor = const Color(0xFF00D4AA);
   @override
   final Color progressBarNotPassedColor =
       const Color.fromRGBO(194, 203, 210, 1);
@@ -202,7 +201,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   final Color smartchainLabelBorderColor = const Color.fromRGBO(32, 22, 49, 1);
   @override
   final Color mainMenuSelectedItemBackgroundColor =
-      const Color.fromRGBO(146, 187, 255, 0.12);
+      const Color.fromRGBO(0, 212, 170, 0.12);
   @override
   final Color searchFieldMobile = const Color.fromRGBO(42, 47, 62, 1);
   @override

--- a/app_theme/lib/src/dark/theme_global_dark.dart
+++ b/app_theme/lib/src/dark/theme_global_dark.dart
@@ -14,9 +14,9 @@ ThemeData get themeGlobalDark {
   //TODO! Implement all light-theme equivalent properties
   final ColorScheme colorScheme = ColorScheme.fromSeed(
     brightness: Brightness.dark,
-    seedColor: const Color.fromRGBO(61, 119, 233, 1),
-    primary: const Color.fromRGBO(61, 119, 233, 1),
-    secondary: const Color.fromRGBO(90, 104, 230, 1),
+    seedColor: const Color(0xFF00D4AA),
+    primary: const Color(0xFF00D4AA),
+    secondary: const Color(0xFF00C3AA),
     tertiary: const Color.fromRGBO(28, 32, 59, 1), // - @ColorScheme: Updated
     surface: const Color.fromRGBO(22, 25, 39, 1),
     onSurface: const Color.fromRGBO(18, 20, 32, 1),
@@ -81,7 +81,7 @@ ThemeData get themeGlobalDark {
     cardTheme: CardThemeData(
       color: colorScheme.surface,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(18)),
+        borderRadius: BorderRadius.all(Radius.circular(12)),
       ),
     ),
     colorScheme: colorScheme,

--- a/app_theme/lib/src/light/theme_custom_light.dart
+++ b/app_theme/lib/src/light/theme_custom_light.dart
@@ -49,20 +49,20 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   @override
   final Color fiatAmountColor = const Color.fromRGBO(168, 177, 185, 1);
   @override
-  final Color headerFloatBoxColor = const Color.fromRGBO(98, 121, 233, 1);
+  final Color headerFloatBoxColor = const Color(0xFF00D4AA);
   @override
-  final Color headerIconColor = const Color.fromRGBO(34, 121, 241, 1);
+  final Color headerIconColor = const Color(0xFF00D4AA);
   @override
   final Color buttonColorDefault = const Color.fromRGBO(245, 249, 255, 1);
   @override
-  final Color buttonColorDefaultHover = const Color.fromRGBO(76, 128, 233, 1);
+  final Color buttonColorDefaultHover = const Color(0xFF00D4AA);
   @override
   final Color buttonTextColorDefaultHover =
       const Color.fromRGBO(245, 249, 255, 1);
   @override
   final Color noColor = Colors.transparent;
   @override
-  final Color increaseColor = const Color.fromRGBO(0, 192, 88, 1);
+  final Color increaseColor = const Color(0xFF00D4AA);
   @override
   final Color decreaseColor = const Color.fromRGBO(229, 33, 103, 1);
   @override
@@ -93,7 +93,7 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   @override
   final Color defaultGradientButtonTextColor = Colors.white;
   @override
-  final Color defaultCheckboxColor = const Color.fromRGBO(81, 121, 233, 1);
+  final Color defaultCheckboxColor = const Color(0xFF00D4AA);
   @override
   final Gradient defaultSwitchColor = const LinearGradient(
     stops: [0, 93],
@@ -114,8 +114,7 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   @override
   final Color rewardBoxShadowColor = const Color.fromRGBO(0, 0, 0, 0.1);
   @override
-  final Color defaultBorderButtonBorder =
-      const Color.fromRGBO(136, 146, 235, 1);
+  final Color defaultBorderButtonBorder = const Color(0xFF00D4AA);
   @override
   final Color successColor = const Color.fromRGBO(0, 192, 88, 1);
   @override
@@ -190,7 +189,7 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   @override
   final Color progressBarColor = const Color.fromRGBO(69, 96, 120, 0.33);
   @override
-  final Color progressBarPassedColor = const Color.fromRGBO(137, 147, 236, 1);
+  final Color progressBarPassedColor = const Color(0xFF00D4AA);
   @override
   final Color progressBarNotPassedColor =
       const Color.fromRGBO(194, 203, 210, 1);
@@ -202,10 +201,10 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   final Color smartchainLabelBorderColor = const Color.fromRGBO(32, 22, 49, 1);
   @override
   final Color mainMenuSelectedItemBackgroundColor =
-      const Color.fromRGBO(146, 187, 255, 0.12);
+      const Color.fromRGBO(0, 212, 170, 0.12);
   @override
   final Color selectedMenuBackgroundColor =
-      const Color.fromRGBO(146, 187, 255, 0.12);
+      const Color.fromRGBO(0, 212, 170, 0.12);
   @override
   final Color searchFieldMobile = const Color.fromRGBO(239, 240, 242, 1);
   @override

--- a/app_theme/lib/src/light/theme_global_light.dart
+++ b/app_theme/lib/src/light/theme_global_light.dart
@@ -12,8 +12,8 @@ ThemeData get themeGlobalLight {
       );
 
   final ColorScheme colorScheme = const ColorScheme.light().copyWith(
-    primary: const Color.fromRGBO(90, 104, 230, 1),
-    secondary: const Color.fromRGBO(73, 134, 234, 1),
+    primary: const Color(0xFF00D4AA),
+    secondary: const Color(0xFF00C3AA),
     tertiary: const Color.fromARGB(255, 192, 225, 255),
     surface: const Color.fromRGBO(255, 255, 255, 1),
     onSurface: const Color.fromRGBO(251, 251, 251, 1),
@@ -78,7 +78,7 @@ ThemeData get themeGlobalLight {
     cardTheme: CardThemeData(
       color: colorScheme.surface,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(18)),
+        borderRadius: BorderRadius.all(Radius.circular(12)),
       ),
     ),
     colorScheme: colorScheme,

--- a/app_theme/lib/src/new_theme/new_theme_dark.dart
+++ b/app_theme/lib/src/new_theme/new_theme_dark.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 import '../../app_theme.dart';
 
 const ColorSchemeExtension _colorSchemeExtension = ColorSchemeExtension(
-  primary: Color.fromRGBO(61, 119, 233, 1),
-  p50: Color.fromRGBO(31, 60, 117, 1),
-  p40: Color.fromRGBO(24, 48, 93, 1),
-  p10: Color.fromRGBO(6, 12, 23, 1),
+  primary: Color(0xFF00D4AA),
+  p50: Color(0xFF006B55),
+  p40: Color(0xFF005544),
+  p10: Color(0xFF001511),
   secondary: Color.fromRGBO(173, 175, 196, 1),
   s70: Color.fromRGBO(121, 123, 137, 1),
   s50: Color.fromRGBO(87, 88, 98, 1),

--- a/app_theme/lib/src/new_theme/new_theme_light.dart
+++ b/app_theme/lib/src/new_theme/new_theme_light.dart
@@ -2,10 +2,10 @@ import 'package:app_theme/app_theme.dart';
 import 'package:flutter/material.dart';
 
 const ColorSchemeExtension _colorSchemeExtension = ColorSchemeExtension(
-  primary: Color.fromRGBO(61, 119, 233, 1),
-  p50: Color.fromRGBO(158, 187, 244, 1),
-  p40: Color.fromRGBO(177, 201, 246, 1),
-  p10: Color.fromRGBO(236, 241, 253, 1),
+  primary: Color(0xFF00D4AA),
+  p50: Color(0xFF006B55),
+  p40: Color(0xFF005544),
+  p10: Color(0xFF001511),
   secondary: Color.fromRGBO(69, 96, 120, 1),
   s70: Color.fromRGBO(125, 144, 161, 1),
   s50: Color.fromRGBO(162, 175, 187, 1),


### PR DESCRIPTION
## Summary
- switch to teal primary/secondary colors
- reduce card border radius for flatter look
- adjust custom colors for dark and light themes
- modify new theme extensions for teal palette
- soften popup shadow

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686fd05a784c8326987c2018e76765fa