### PR TITLE
fix(wallet): add spacing to faucet button

### DIFF
--- a/lib/views/wallet/coin_details/faucet/faucet_button.dart
+++ b/lib/views/wallet/coin_details/faucet/faucet_button.dart
@@ -92,6 +92,7 @@ class _FaucetButtonState extends State<FaucetButton> {
                   children: [
                     Icon(Icons.local_drink_rounded,
                         color: Colors.blue, size: isMobile ? 14 : 16),
+                    const SizedBox(width: 4),
                     Text(
                       LocaleKeys.faucet.tr(),
                       style: TextStyle(


### PR DESCRIPTION
## Summary
- add a small gap between icon and text of the faucet button

## Testing
- `flutter analyze`
- `flutter pub get --offline`


------
https://chatgpt.com/codex/tasks/task_e_687f78465a4083268e15c92e4774464e