### PR TITLE
hide bot & password settings for trezor

### DIFF
--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -30,10 +30,14 @@ class GeneralSettings extends StatelessWidget {
         const SizedBox(height: 25),
         const SettingsManageTestCoins(),
         const SizedBox(height: 25),
-        const SettingsManageWeakPasswords(),
+        const HiddenWithoutWallet(
+          isHiddenForHw: true,
+          child: SettingsManageWeakPasswords(),
+        ),
         const SizedBox(height: 25),
         if (context.watch<TradingStatusBloc>().state is TradingEnabled)
           const HiddenWithoutWallet(
+            isHiddenForHw: true,
             child: SettingsManageTradingBot(),
           ),
         const SizedBox(height: 25),


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet/issues/2885

To test:
- login with trezor
- go to settings
- confirm "allow weak password" and "enable trading bot" **are not** visible.
- log in without hardware wallet
- confirm "allow weak password" and "enable trading bot" **are** visible.

