### PR TITLE
linux: guard `G_APPLICATION_DEFAULT_FLAGS` behind GLib ≥ 2.74, fallba…

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -8,6 +8,12 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
+#if GLIB_CHECK_VERSION(2,74,0)
+  #define MY_APP_DEFAULT_FLAGS G_APPLICATION_DEFAULT_FLAGS
+#else
+  #define MY_APP_DEFAULT_FLAGS G_APPLICATION_FLAGS_NONE
+#endif
+
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
@@ -131,6 +137,6 @@ static void my_application_init(MyApplication* self) {
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_DEFAULT_FLAGS,
+                                     "flags", MY_APP_DEFAULT_FLAGS,
                                      nullptr));
 }


### PR DESCRIPTION
…ck to `G_APPLICATION_FLAGS_NONE`

* Use `GLIB_CHECK_VERSION(2,74,0)` to select `G_APPLICATION_DEFAULT_FLAGS` when available, otherwise use `G_APPLICATION_FLAGS_NONE`.
* Resolves build failures with older GLib headers while keeping the preferred constant on newer systems.
* No functional changes; improves cross-distro compatibility.

Solve: https://github.com/KomodoPlatform/komodo-wallet/pull/3063#issuecomment-3217399576