### PR TITLE
fix logging of apiCommitHash to output actual value instead of closure

### DIFF
--- a/lib/bloc/version_info/version_info_bloc.dart
+++ b/lib/bloc/version_info/version_info_bloc.dart
@@ -66,7 +66,7 @@ class VersionInfoBloc extends Bloc<VersionInfoEvent, VersionInfoState> {
       emit(basicInfo.copyWith(apiCommitHash: apiCommitHash));
       _logger.info(
         'MM2 API version loaded successfully - Version: $apiVersion, '
-        'Commit: $apiCommitHash',
+        'Commit: ${apiCommitHash?.call()}',
       );
     } catch (e, s) {
       _logger.severe('Failed to load MM2 API version', e, s);


### PR DESCRIPTION
Previously, when logging `apiCommitHash`, the code printed the function reference (e.g. Closure: () => String) instead of the actual hash value.

Example:

```
2025-8-29: 18:38:32.869T+:0:00:00.036927 [LOG] {message: INFO: MM2 API version loaded successfully - Version: 2.5.1-beta_80766b0, Commit: Closure: () => String - null, path: VersionInfoBloc, app_version: 0.9.2, mm2_version: 2.5.1-beta_80766b0, os_language: en-US, screen_size: , timestamp: 1756492712864, date: 2025-08-29 20:38:32.864631}__metadata: {appVersion: null, mm2Version: 2.5.1-beta_80766b0, appLanguage: , platform: linux Linux 6.8.0-65-generic #68~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 15 18:06:34 UTC 2, osLanguage: en-US, screenSize: }
```