### PR TITLE
Update geo-blocking for privacy coins

### DIFF
--- a/lib/bloc/bridge_form/bridge_repository.dart
+++ b/lib/bloc/bridge_form/bridge_repository.dart
@@ -57,6 +57,8 @@ class BridgeRepository {
     coins = removeWalletOnly(coins);
     coins = removeSuspended(coins, await _kdfSdk.auth.isSignedIn());
 
+    // Privacy coin gating is applied at the UI layer for tickers and orders
+
     final CoinsByTicker coinsByTicker = convertToCoinsByTicker(coins);
     final CoinsByTicker multiProtocolCoins =
         removeSingleProtocol(coinsByTicker);

--- a/lib/bloc/coins_bloc/asset_coin_extension.dart
+++ b/lib/bloc/coins_bloc/asset_coin_extension.dart
@@ -22,6 +22,12 @@ extension AssetCoinExtension on Asset {
       contractAddress: contractAddress ?? '',
     );
 
+    final bool isPrivacyCoin =
+        (config.valueOrNull<bool>('is_privacy_coin') ??
+            config.valueOrNull<bool>('isPrivacyCoin') ??
+            false) ||
+        _fallbackPrivacyCoins.contains(id.id);
+
     return Coin(
       type: protocol.subClass.toCoinType(),
       abbr: id.id,
@@ -46,6 +52,7 @@ extension AssetCoinExtension on Asset {
       mode: id.isSegwit ? CoinMode.segwit : CoinMode.standard,
       derivationPath: id.derivationPath,
       decimals: id.chainId.decimals ?? 8,
+      isPrivacyCoin: isPrivacyCoin,
     );
   }
 
@@ -54,6 +61,11 @@ extension AssetCoinExtension on Asset {
   String? get platform =>
       protocol.config.valueOrNull('protocol', 'protocol_data', 'platform');
 }
+
+// Fallback list for privacy coins until all configs include the flag
+const Set<String> _fallbackPrivacyCoins = {
+  'ARRR',
+};
 
 extension CoinTypeExtension on CoinSubClass {
   CoinType toCoinType() {

--- a/lib/bloc/trading_status/trading_status_bloc.dart
+++ b/lib/bloc/trading_status/trading_status_bloc.dart
@@ -20,8 +20,12 @@ class TradingStatusBloc extends Bloc<TradingStatusEvent, TradingStatusState> {
   ) async {
     emit(TradingStatusLoadInProgress());
     try {
-      final enabled = await _repository.isTradingEnabled();
-      emit(enabled ? TradingEnabled() : TradingDisabled());
+      // Prefer the new disallowed features API
+      final features = await _repository.fetchDisallowedFeatures();
+      final enabled = !features.contains('TRADING');
+      emit(enabled
+          ? TradingEnabled(disallowedFeatures: features)
+          : TradingDisabled(disallowedFeatures: features));
 
       // This catch will never be triggered by the repository. This will require
       // changes to meet the "TODO" above.

--- a/lib/bloc/trading_status/trading_status_repository.dart
+++ b/lib/bloc/trading_status/trading_status_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:web_dex/shared/constants.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart' show JsonMap;
 
 class TradingStatusRepository {
   TradingStatusRepository({http.Client? httpClient, Duration? timeout})
@@ -12,20 +13,26 @@ class TradingStatusRepository {
   final http.Client _httpClient;
   final Duration _timeout;
 
-  Future<bool> isTradingEnabled({bool? forceFail}) async {
+  /// Returns the set of disallowed feature identifiers reported by the
+  /// bouncer service. Empty set means no feature is blocked.
+  ///
+  /// Recognized features include (but are not limited to):
+  /// - 'TRADING'
+  /// - 'PRIVACY_COINS'
+  Future<Set<String>> fetchDisallowedFeatures({bool? forceFail}) async {
     try {
       final geoBlock = const String.fromEnvironment('GEO_BLOCK');
       if (geoBlock == 'disabled') {
-        debugPrint('GEO_BLOCK is disabled. Trading enabled.');
-        return true;
+        debugPrint('GEO_BLOCK is disabled. No features are disallowed.');
+        return <String>{};
       }
 
       final apiKey = const String.fromEnvironment('FEEDBACK_API_KEY');
       final bool shouldFail = forceFail ?? false;
 
       if (apiKey.isEmpty && !shouldFail) {
-        debugPrint('FEEDBACK_API_KEY not found. Trading disabled.');
-        return false;
+        debugPrint('FEEDBACK_API_KEY not found. Assuming TRADING disallowed.');
+        return {'TRADING'};
       }
 
       late final Uri uri;
@@ -38,21 +45,46 @@ class TradingStatusRepository {
         headers['X-KW-KEY'] = apiKey;
       }
 
-      final res =
-          await _httpClient.post(uri, headers: headers).timeout(_timeout);
+      final res = await _httpClient
+          .post(uri, headers: headers)
+          .timeout(_timeout);
 
       if (shouldFail) {
-        return res.statusCode == 200;
+        // Fallback behavior for tests: non-200 => treat as trading blocked
+        return res.statusCode == 200 ? <String>{} : {'TRADING'};
       }
 
-      if (res.statusCode != 200) return false;
-      final JsonMap data = jsonFromString(res.body);
-      return !(data.valueOrNull<bool>('blocked') ?? true);
+      if (res.statusCode != 200) return {'TRADING'};
+
+      final JsonMap root = jsonFromString(res.body);
+      // Support both top-level and nested under 'data'
+      final JsonMap payload =
+          (root.valueOrNull<JsonMap>('data') ?? root) as JsonMap;
+
+      final List<dynamic> disallowed =
+          (payload['disallowed_features'] as List<dynamic>?) ?? const [];
+      final Set<String> features = disallowed
+          .map((e) => e.toString().toUpperCase())
+          .toSet();
+
+      // Backward compatibility: if new field is absent, fall back to 'blocked'
+      if (features.isEmpty) {
+        final bool? blocked = payload.valueOrNull<bool>('blocked');
+        if (blocked == true) return {'TRADING'};
+      }
+
+      return features;
     } catch (_) {
-      debugPrint('Network error: Trading status check failed');
-      // Block trading features on network failure
-      return false;
+      debugPrint('Network error: Feature gating check failed');
+      // Block trading features on network failure (conservative)
+      return {'TRADING'};
     }
+  }
+
+  /// Backward-compatible method. Prefer [fetchDisallowedFeatures].
+  Future<bool> isTradingEnabled({bool? forceFail}) async {
+    final features = await fetchDisallowedFeatures(forceFail: forceFail);
+    return !features.contains('TRADING');
   }
 
   void dispose() {

--- a/lib/bloc/trading_status/trading_status_state.dart
+++ b/lib/bloc/trading_status/trading_status_state.dart
@@ -5,14 +5,40 @@ abstract class TradingStatusState extends Equatable {
   List<Object?> get props => [];
 
   bool get isEnabled => this is TradingEnabled;
+
+  /// Set of features that are currently disallowed for the user, e.g.,
+  /// {'TRADING', 'PRIVACY_COINS'}. Defaults to empty for non-loaded states.
+  Set<String> get disallowedFeatures => const {};
 }
 
 class TradingStatusInitial extends TradingStatusState {}
 
 class TradingStatusLoadInProgress extends TradingStatusState {}
 
-class TradingEnabled extends TradingStatusState {}
+class TradingEnabled extends TradingStatusState {
+  TradingEnabled({Set<String>? disallowedFeatures})
+      : _disallowedFeatures = disallowedFeatures ?? const {};
 
-class TradingDisabled extends TradingStatusState {}
+  final Set<String> _disallowedFeatures;
+
+  @override
+  List<Object?> get props => [_disallowedFeatures];
+
+  @override
+  Set<String> get disallowedFeatures => _disallowedFeatures;
+}
+
+class TradingDisabled extends TradingStatusState {
+  TradingDisabled({Set<String>? disallowedFeatures})
+      : _disallowedFeatures = disallowedFeatures ?? const {};
+
+  final Set<String> _disallowedFeatures;
+
+  @override
+  List<Object?> get props => [_disallowedFeatures];
+
+  @override
+  Set<String> get disallowedFeatures => _disallowedFeatures;
+}
 
 class TradingStatusLoadFailure extends TradingStatusState {}

--- a/lib/model/coin.dart
+++ b/lib/model/coin.dart
@@ -31,6 +31,7 @@ class Coin extends Equatable {
     this.coinpaprikaId,
     this.activeByDefault = false,
     this.isCustomCoin = false,
+    this.isPrivacyCoin = false,
     required String? swapContractAddress,
     required bool walletOnly,
     required this.mode,
@@ -60,6 +61,7 @@ class Coin extends Equatable {
 
   final bool isTestCoin;
   bool isCustomCoin;
+  final bool isPrivacyCoin;
 
   @Deprecated(
     '$_urgentDeprecationNotice Use the SDK\'s Asset multi-address support instead. The wallet now works with multiple addresses per account.',
@@ -195,6 +197,7 @@ class Coin extends Equatable {
     String? address,
     double? sendableBalance,
     bool? isCustomCoin,
+    bool? isPrivacyCoin,
   }) {
     return Coin(
         type: type ?? this.type,
@@ -222,6 +225,7 @@ class Coin extends Equatable {
         walletOnly: walletOnly ?? _walletOnly,
         mode: mode ?? this.mode,
         isCustomCoin: isCustomCoin ?? this.isCustomCoin,
+        isPrivacyCoin: isPrivacyCoin ?? this.isPrivacyCoin,
       )
       ..address = address ?? this.address
       ..sendableBalance = sendableBalance ?? this.sendableBalance;

--- a/lib/views/bridge/view/table/bridge_target_protocols_table.dart
+++ b/lib/views/bridge/view/table/bridge_target_protocols_table.dart
@@ -16,6 +16,7 @@ import 'package:web_dex/views/bridge/bridge_group.dart';
 import 'package:web_dex/views/bridge/view/table/bridge_nothing_found.dart';
 import 'package:web_dex/views/bridge/view/table/bridge_protocol_table_order_item.dart';
 import 'package:web_dex/views/bridge/view/table/bridge_table_column_heads.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 
 class BridgeTargetProtocolsTable extends StatefulWidget {
   const BridgeTargetProtocolsTable({
@@ -109,6 +110,14 @@ class _TargetProtocolItems extends StatelessWidget {
     if (sellCoin == null) return BridgeNothingFound();
 
     final targetsList = bloc.prepareTargetsList(bestOrders);
+    // Apply privacy coin gating to target orders
+    final tradingStatus = context.read<TradingStatusBloc>().state;
+    if (tradingStatus.disallowedFeatures.contains('PRIVACY_COINS')) {
+      targetsList.removeWhere((order) {
+        final coin = RepositoryProvider.of<CoinsRepo>(context).getCoin(order.coin);
+        return coin?.isPrivacyCoin == true;
+      });
+    }
     if (targetsList.isEmpty) return BridgeNothingFound();
 
     final scrollController = ScrollController();

--- a/lib/views/bridge/view/table/bridge_tickers_list.dart
+++ b/lib/views/bridge/view/table/bridge_tickers_list.dart
@@ -13,6 +13,7 @@ import 'package:web_dex/model/typedef.dart';
 import 'package:web_dex/shared/ui/borderless_search_field.dart';
 import 'package:web_dex/shared/ui/ui_flat_button.dart';
 import 'package:web_dex/views/bridge/bridge_ticker_selector.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/views/bridge/bridge_tickers_list_item.dart';
 import 'package:web_dex/views/dex/simple/form/tables/nothing_found.dart';
 
@@ -109,6 +110,14 @@ class _BridgeTickersListState extends State<BridgeTickersList> {
           previousValue.add(element.value.first);
           return previousValue;
         });
+
+        // Apply privacy coin gating
+        final tradingStatus = context.read<TradingStatusBloc>().state;
+        final bool privacyCoinsBlocked =
+            tradingStatus.disallowedFeatures.contains('PRIVACY_COINS');
+        if (privacyCoinsBlocked) {
+          coinsList.removeWhere((c) => c.isPrivacyCoin);
+        }
 
         if (_searchTerm != null && _searchTerm!.isNotEmpty) {
           final String searchTerm = _searchTerm!.toLowerCase();


### PR DESCRIPTION
Implement `disallowed_features` from the bouncer endpoint to enable granular feature blocking (e.g., trading, privacy coins) based on user location and mark ARRR as a privacy coin.

The bouncer endpoint now provides a `disallowed_features` array (e.g., `['TRADING', 'PRIVACY_COINS']`) instead of a simple `blocked` boolean. This PR updates the application to consume this new API, allowing specific features like trading or privacy coin access to be restricted. The legacy `blocked` flag is retained for backward compatibility as a fallback. This change is crucial for the ARRR release to enforce privacy coin restrictions in certain regions, such as UAE. The `GEO_BLOCK=disabled` environment variable continues to override all geo-blocking.

---
<a href="https://cursor.com/background-agent?bcId=bc-61d9e9dc-3dd4-43d3-8ef2-da3e4d553e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61d9e9dc-3dd4-43d3-8ef2-da3e4d553e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

