### PR TITLE
fix: route sdk logs through app logger

### DIFF
--- a/lib/mm2/mm2.dart
+++ b/lib/mm2/mm2.dart
@@ -18,6 +18,7 @@ final class MM2 {
         preActivateHistoricalAssets: false,
         preActivateDefaultAssets: false,
       ),
+      onLog: _handleSdkLog,
     );
   }
 
@@ -65,10 +66,12 @@ final class MM2 {
     return response.result;
   }
 
-  @Deprecated('Use KomodoDefiSdk.client.rpc or KomodoDefiSdk.client.executeRpc '
-      'instead. This method is the legacy way of calling RPC methods which '
-      'injects an empty user password into the legacy models which override '
-      'the legacy base RPC request model')
+  @Deprecated(
+    'Use KomodoDefiSdk.client.rpc or KomodoDefiSdk.client.executeRpc '
+    'instead. This method is the legacy way of calling RPC methods which '
+    'injects an empty user password into the legacy models which override '
+    'the legacy base RPC request model',
+  )
   Future<JsonMap> call(dynamic request) async {
     try {
       final dynamic requestWithUserpass = _assertPass(request);
@@ -76,9 +79,9 @@ final class MM2 {
           ? JsonMap.from(requestWithUserpass)
           // ignore: avoid_dynamic_calls
           : (requestWithUserpass?.toJson != null
-              // ignore: avoid_dynamic_calls
-              ? requestWithUserpass.toJson() as JsonMap
-              : requestWithUserpass as JsonMap);
+                // ignore: avoid_dynamic_calls
+                ? requestWithUserpass.toJson() as JsonMap
+                : requestWithUserpass as JsonMap);
 
       return await _kdfSdk.client.executeRpc(jsonRequest);
     } catch (e) {
@@ -106,6 +109,10 @@ final class MM2 {
     }
 
     return req;
+  }
+
+  void _handleSdkLog(String message) {
+    log(message, path: 'KomodoDefiSdk').ignore();
   }
 }
 


### PR DESCRIPTION
## Summary
- forward KomodoDefiSdk log stream entries into the app logger by wiring the onLog callback

## Testing
- flutter analyze *(fails: The current Flutter SDK version is 3.32.5 but the project requires >=3.35.3)*

------
https://chatgpt.com/codex/tasks/task_e_68db7b2f37dc8326aaae805c872237fc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Forwards KomodoDefiSdk logs to the app logger by wiring `onLog` in `MM2` and adding a `_handleSdkLog` handler.
> 
> - **Logging**:
>   - Wire `KomodoDefiSdk` `onLog` callback in `MM2` constructor to route SDK logs.
>   - Add `_handleSdkLog` to forward messages via `log(..., path: 'KomodoDefiSdk').ignore()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b8d798c8ef0cebb147bd4a96cea6da557b494a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->