### PR TITLE
feat: add icon precaching config toggle

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -24,6 +24,9 @@ final Uri discordInviteUrl = Uri.parse('https://komodoplatform.com/discord');
 /// Const to define if Bitrefill integration is enabled in the app.
 const bool isBitrefillIntegrationEnabled = false;
 
+/// Controls whether asset icons are precached when the app starts.
+const bool isIconPrecachingEnabled = false;
+
 /// Const to define whether to show trading warning dialogs and notices.
 /// This can be used to control the display of trading-related warnings
 /// throughout the application.

--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -366,8 +366,10 @@ class _MyAppViewState extends State<_MyAppView> {
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final sdk = RepositoryProvider.of<KomodoDefiSdk>(context);
-    _precacheCoinIcons(sdk).ignore();
+    if (isIconPrecachingEnabled) {
+      final sdk = RepositoryProvider.of<KomodoDefiSdk>(context);
+      _precacheCoinIcons(sdk).ignore();
+    }
   }
 
   /// Hides the native app launch loader. Currently only implemented for web.


### PR DESCRIPTION
## Summary
- add an app-level configuration flag to control icon precaching
- guard the coin icon precache routine behind the new configuration toggle

## Testing
- flutter analyze *(fails: The current Flutter SDK version is 3.32.5 but web_dex requires >=3.35.3)*

------
https://chatgpt.com/codex/tasks/task_e_68e940bbbf80832693076aa4d39dc72e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `isIconPrecachingEnabled` (default false) and conditionally run coin icon precaching in `didChangeDependencies()`.
> 
> - **Config**:
>   - Add `isIconPrecachingEnabled` (default `false`) in `lib/app_config/app_config.dart` to control asset icon precaching.
> - **App lifecycle**:
>   - Guard `_precacheCoinIcons(...)` in `_MyAppViewState.didChangeDependencies()` behind `isIconPrecachingEnabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 442140ade71de93cd530b78ca4d9952501b37c2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->