### PR TITLE
ci: use flutter build bundle for dry build in generate-assets

### DIFF
--- a/.github/actions/generate-assets/action.yml
+++ b/.github/actions/generate-assets/action.yml
@@ -158,7 +158,8 @@ runs:
         # after the assets are downloaded to register them in AssetManifest.bin
         echo ""
         flutter pub get --enforce-lockfile > /dev/null 2>&1 || true
-        $BUILD_CMD > /dev/null 2>&1 || true
+        DRY_BUILD_CMD=$(echo "$BUILD_CMD" | sed -E 's/^flutter build [^ ]+/flutter build bundle/')
+        $DRY_BUILD_CMD > /dev/null 2>&1 || true
         rm -rf build/*
 
         # Run flutter build and capture its output


### PR DESCRIPTION
This updates the initial dry build in `.github/actions/generate-assets/action.yml` to use:

- `flutter build bundle [existing args]`

The rest of the build remains unchanged. This avoids platform-specific build invocations during the pre-fetch/registration step while preserving all flags via sed transform.

Branch: fix/native-ci-dry-builds
Target: dev
