### PR TITLE
use AnalyticsRepo to enqueue NFT analytics events

### DIFF
--- a/lib/bloc/market_maker_bot/market_maker_bot/market_maker_bot_bloc.dart
+++ b/lib/bloc/market_maker_bot/market_maker_bot/market_maker_bot_bloc.dart
@@ -10,7 +10,7 @@ import 'package:web_dex/bloc/settings/settings_repository.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/market_maker_bot/trade_coin_pair_config.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/rpc_error.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/rpc_error_type.dart';
-import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
 import 'package:web_dex/analytics/events/market_bot_events.dart';
 import 'package:get_it/get_it.dart';
 
@@ -69,7 +69,7 @@ class MarketMakerBotBloc
         return;
       }
       // Log bot error
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         MarketbotErrorEventData(
           failureDetail: 'start_failed',
           strategyType: 'simple',
@@ -93,7 +93,7 @@ class MarketMakerBotBloc
       emit(const MarketMakerBotState.stopped());
     } catch (e) {
       // Log bot error
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         MarketbotErrorEventData(
           failureDetail: 'stop_failed',
           strategyType: 'simple',
@@ -139,7 +139,7 @@ class MarketMakerBotBloc
       );
       emit(stoppingState);
       // Log bot error
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         MarketbotErrorEventData(
           failureDetail: 'update_failed',
           strategyType: 'simple',
@@ -186,7 +186,7 @@ class MarketMakerBotBloc
       );
       emit(stoppingState);
       // Log bot error
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         MarketbotErrorEventData(
           failureDetail: 'cancel_failed',
           strategyType: 'simple',
@@ -211,7 +211,7 @@ class MarketMakerBotBloc
       if (DateTime.now().difference(start) > timeout) {
         if (fatalTimeout) {
           // Log bot error
-          GetIt.I<AnalyticsBloc>().logEvent(
+          GetIt.I<AnalyticsRepo>().queueEvent(
             MarketbotErrorEventData(
               failureDetail: 'timeout_cancelling',
               strategyType: 'simple',

--- a/lib/bloc/nft_withdraw/nft_withdraw_bloc.dart
+++ b/lib/bloc/nft_withdraw/nft_withdraw_bloc.dart
@@ -18,7 +18,7 @@ import 'package:web_dex/mm2/mm2_api/rpc/send_raw_transaction/send_raw_transactio
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/nft.dart';
 import 'package:web_dex/model/text_error.dart';
-import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
 import 'package:get_it/get_it.dart';
 import 'package:web_dex/shared/utils/extensions/kdf_user_extensions.dart';
 
@@ -100,7 +100,7 @@ class NftWithdrawBloc extends Bloc<NftWithdrawEvent, NftWithdrawState> {
 
     try {
       // Log initiated
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         NftTransferInitiatedEventData(
           collectionName: nft.collectionName ?? nft.symbol ?? 'unknown',
           tokenId: nft.tokenId,
@@ -126,7 +126,7 @@ class NftWithdrawBloc extends Bloc<NftWithdrawEvent, NftWithdrawState> {
       );
     } on ApiError catch (e) {
       // Log failure
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         NftTransferFailureEventData(
           collectionName:
               state.nft.collectionName ?? state.nft.symbol ?? 'unknown',
@@ -137,7 +137,7 @@ class NftWithdrawBloc extends Bloc<NftWithdrawEvent, NftWithdrawState> {
 
       emit(state.copyWith(sendError: () => e, isSending: () => false));
     } on TransportError catch (e) {
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         NftTransferFailureEventData(
           collectionName:
               state.nft.collectionName ?? state.nft.symbol ?? 'unknown',
@@ -176,7 +176,7 @@ class NftWithdrawBloc extends Bloc<NftWithdrawEvent, NftWithdrawState> {
 
     if (txHash == null) {
       // Log failure
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         NftTransferFailureEventData(
           collectionName:
               state.nft.collectionName ?? state.nft.symbol ?? 'unknown',
@@ -196,7 +196,7 @@ class NftWithdrawBloc extends Bloc<NftWithdrawEvent, NftWithdrawState> {
       // Log success with fee
       final fee =
           double.tryParse(state.txDetails.feeDetails.feeValue ?? '0') ?? 0.0;
-      GetIt.I<AnalyticsBloc>().logEvent(
+      GetIt.I<AnalyticsRepo>().queueEvent(
         NftTransferSuccessEventData(
           collectionName:
               state.nft.collectionName ?? state.nft.symbol ?? 'unknown',


### PR DESCRIPTION
Fixes bug blocking NFT withdraws. Previously the errors below would happen on click.

<img width="911" height="572" alt="image" src="https://github.com/user-attachments/assets/d867042a-1800-4621-a471-828779c4cf8c" />

```
AppBlocObserver -> onError
NftWithdrawBloc: Bad state: GetIt: Object/factory with type AnalyticsBloc is not registered inside GetIt. 
(Did you accidentally do GetIt sl=GetIt.instance(); instead of GetIt sl=GetIt.instance;
Did you forget to register it?)
Trace: #0      throwIfNot (package:get_it/get_it_impl.dart:14)
#1      _GetItImplementation._findRegistrationByNameAndType (package:get_it/get_it_impl.dart:583)
#2      _GetItImplementation._get (package:get_it/get_it_impl.dart:641)
#3      _GetItImplementation.get (package:get_it/get_it_impl.dart:608)
#4      _GetItImplementation.call (package:get_it/get_it_impl.dart:720)
#5      NftWithdrawBloc._onSend (package:web_dex/bloc/nft_withdraw/nft_withdraw_bloc.dart:103)
<asynchronous suspension>
#6      Bloc.on.<anonymous closure>.handleEvent (package:bloc/src/bloc.dart:226)
<asynchronous suspension>

[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Bad state: GetIt: Object/factory with type AnalyticsBloc is not registered inside GetIt. 
(Did you accidentally do GetIt sl=GetIt.instance(); instead of GetIt sl=GetIt.instance;
Did you forget to register it?)
#0      throwIfNot (package:get_it/get_it_impl.dart:14)
#1      _GetItImplementation._findRegistrationByNameAndType (package:get_it/get_it_impl.dart:583)
#2      _GetItImplementation._get (package:get_it/get_it_impl.dart:641)
#3      _GetItImplementation.get (package:get_it/get_it_impl.dart:608)
#4      _GetItImplementation.call (package:get_it/get_it_impl.dart:720)
#5      NftWithdrawBloc._onSend (package:web_dex/bloc/nft_withdraw/nft_withdraw_bloc.dart:103)
<asynchronous suspension>
#6      Bloc.on.<anonymous closure>.handleEvent (package:bloc/src/bloc.dart:226)
<asynchronous suspension>
```

To Test:
- attempt to withdraw an NFT. If you succeeds, it worked.