### PR TITLE
fix: differentiate swap and order uuids

### DIFF
--- a/lib/views/dex/dex_page.dart
+++ b/lib/views/dex/dex_page.dart
@@ -48,7 +48,6 @@ class _DexPageState extends State<DexPage> {
     );
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final myOrdersService = RepositoryProvider.of<MyOrdersService>(context);
-
     final pageContent = MultiBlocProvider(
       providers: [
         BlocProvider<DexTabBarBloc>(
@@ -64,9 +63,17 @@ class _DexPageState extends State<DexPage> {
           )..add(const ListenToOrdersRequested()),
         ),
       ],
-      child: isTradingDetails
-          ? TradingDetails(uuid: routingState.dexState.uuid)
-          : _DexContent(),
+      child: BlocBuilder<DexTabBarBloc, DexTabBarState>(
+        builder: (context, state) {
+          final tab = DexListType.values[state.tabIndex];
+          final kind = tab == DexListType.orders
+              ? TradingEntityKind.order
+              : TradingEntityKind.swap;
+          return isTradingDetails
+              ? TradingDetails(uuid: routingState.dexState.uuid, kind: kind)
+              : _DexContent();
+        },
+      ),
     );
     return ZhtlcConfigurationHandler(child: pageContent);
   }

--- a/lib/views/market_maker_bot/market_maker_bot_page.dart
+++ b/lib/views/market_maker_bot/market_maker_bot_page.dart
@@ -12,6 +12,7 @@ import 'package:web_dex/bloc/market_maker_bot/market_maker_trade_form/market_mak
 import 'package:web_dex/bloc/settings/settings_repository.dart';
 import 'package:web_dex/blocs/trading_entities_bloc.dart';
 import 'package:web_dex/model/authorize_mode.dart';
+import 'package:web_dex/model/dex_list_type.dart';
 import 'package:web_dex/router/state/routing_state.dart';
 import 'package:web_dex/services/orders_service/my_orders_service.dart';
 import 'package:web_dex/views/dex/entity_details/trading_details.dart';
@@ -85,9 +86,17 @@ class _MarketMakerBotPageState extends State<MarketMakerBotPage> {
                 .add(const MarketMakerBotStopRequested());
           }
         },
-        child: isTradingDetails
-            ? TradingDetails(uuid: routingState.marketMakerState.uuid)
-            : MarketMakerBotView(),
+        child: BlocBuilder<DexTabBarBloc, DexTabBarState>(
+          builder: (context, state) {
+            final tab = DexListType.values[state.tabIndex];
+            final kind = tab == DexListType.orders
+                ? TradingEntityKind.order
+                : TradingEntityKind.swap;
+            return isTradingDetails
+                ? TradingDetails(uuid: routingState.marketMakerState.uuid, kind: kind)
+                : MarketMakerBotView();
+          },
+        ),
       ),
     );
     return pageContent;


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/3216 &  https://github.com/KomodoPlatform/komodo-wallet/issues/3000 (duplicate)

- Adds TradingEntityKind enum to differentiate swap and order uuids
- checks active tab to assign as swap or order kind
- Sends swap uuids to `dexRepository.getSwapStatus`
- Sends order uuids to `myOrdersService.getStatus`

To test:
- Create a **maker** order.
- Open the maker order detail page
- Confirm no error like `No swap with uuid 99852262-0eb2-4147-93db-d7ef725a0e7e` in console logs for the **order**'s UUID.

Note: the `No swap with uuid` error may be seen immediately after placing a **taker** order, as the app queries for status without enough delay for KDF to have the data ready. This should be resolved in a separate PR, and sighting of these is pre-existing condition not related to this PR.