### PR TITLE
add qr code scan button to nft withdraw input

### DIFF
--- a/lib/views/nfts/details_page/withdraw/nft_withdraw_form.dart
+++ b/lib/views/nfts/details_page/withdraw/nft_withdraw_form.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +11,8 @@ import 'package:web_dex/bloc/withdraw_form/withdraw_form_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/base.dart';
 import 'package:web_dex/model/nft.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:komodo_ui/komodo_ui.dart';
 
 class NftWithdrawForm extends StatelessWidget {
   const NftWithdrawForm({
@@ -137,6 +141,24 @@ class __AddressFieldState extends State<_AddressField> {
       focusedBorder: errorBorder,
       validator: (_) => error is MixedCaseAddressError ? null : error?.message,
       errorMaxLines: 2,
+      suffixIcon: (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+          ? IconButton(
+              icon: const Icon(Icons.qr_code_scanner),
+              onPressed: () async {
+                final scanned = await Navigator.push<String>(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const QrCodeReaderOverlay(),
+                  ),
+                );
+
+                if (!mounted) return;
+                context
+                    .read<NftWithdrawBloc>()
+                    .add(NftWithdrawAddressChanged(scanned ?? ''));
+              },
+            )
+          : null,
     );
   }
 }


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet/issues/3203

To test:
- login to a wallet with an nft and gas to send it on mobile app
- see qr code button on nft withdraw form
- use qr code button on nft withdraw form
- confirm successful withdrawal.

Note:
- The QR code button in NFT withdraw address input is only applied to mobile native apps. 
- Currently, the regular withdraw form shows the QR code in all platforms. 

I'm unsure of the prevalence or utility of having the QR code in non-mobile builds. On my desktop with no camera, it leads to an error page - though on laptop, it spawns the webcam. 
<img width="789" height="318" alt="image" src="https://github.com/user-attachments/assets/389a1d98-04f6-4454-818f-4a1c3963b613" />

Suggest we either remove it for non-mobile, or add some form of camera detection to return an error message like "No camera - unable to scan QR codes".