### PR TITLE
fix(text-input-action): use contextual input actions other than none

### DIFF
--- a/lib/views/settings/widgets/security_settings/password_update_page.dart
+++ b/lib/views/settings/widgets/security_settings/password_update_page.dart
@@ -2,7 +2,6 @@ import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:web_dex/shared/constants.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
@@ -14,6 +13,7 @@ import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/wallet.dart';
+import 'package:web_dex/shared/constants.dart';
 import 'package:web_dex/shared/utils/validators.dart';
 import 'package:web_dex/shared/widgets/password_visibility_control.dart';
 import 'package:web_dex/views/common/page_header/page_header.dart';
@@ -366,7 +366,10 @@ class _PasswordField extends StatelessWidget {
     return UiTextFormField(
       autofocus: true,
       controller: controller,
-      textInputAction: TextInputAction.none,
+      // Use .next, rather than done or go, as this is a generic password field
+      // that is not guaranteed to be the last field in the forms it is
+      // referenced in
+      textInputAction: TextInputAction.next,
       autocorrect: false,
       enableInteractiveSelection: true,
       obscureText: isObscured,

--- a/lib/views/wallet/coins_manager/coins_manager_controls.dart
+++ b/lib/views/wallet/coins_manager/coins_manager_controls.dart
@@ -94,7 +94,7 @@ class _CoinsManagerFiltersState extends State<CoinsManagerFilters> {
           : null,
       autocorrect: false,
       autofocus: true,
-      textInputAction: TextInputAction.none,
+      textInputAction: TextInputAction.search,
       enableInteractiveSelection: true,
       prefixIcon: const Icon(Icons.search, size: 18),
       inputFormatters: [LengthLimitingTextInputFormatter(40)],

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_manager_search_field.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_manager_search_field.dart
@@ -36,7 +36,7 @@ class _WalletManagerSearchFieldState extends State<WalletManagerSearchField> {
       controller: _searchController,
       focusNode: _focusNode,
       autocorrect: false,
-      textInputAction: TextInputAction.none,
+      textInputAction: TextInputAction.search,
       enableInteractiveSelection: true,
       inputFormatters: [LengthLimitingTextInputFormatter(40)],
       decoration: InputDecoration(


### PR DESCRIPTION
`TextInputAction.none` is not supported on iOS and throws errors in debug mode when attempting to use the affected inputs below, preventing the keyboard from appearing.

According to the documentation,
> when running in debug mode, an error will be thrown. If the same thing is done in release mode, then instead of sending the inappropriate value, Android will use "unspecified" on the platform side and iOS will use "default" on the platform side.

UI components affected
- Unauthenticated asset list search bar
- Wallet overview search bar 
- Add asset (activation) view search bar
- Change your password dialog (Settings -> Security -> Change your password)


## Expected behaviour

Wallet overview search bar: 
- tapping the search bar should open a keyboard, and 
- tapping Enter/Done on the keyboard should dismiss it. Note: scrolling or tapping outside the keyboard does not dismiss it.

Add asset view search bar: 
 - tapping the "+" (Add Assets) button should open the Add Assets page, which should automatically open the keyboard.
 - tapping Enter/Done on the keyboard should dismiss it

Password change page:
- upon opening the password change page, the keyboard should appear
- tapping Enter/Done/Next should navigate to the next input field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard behavior for password and search input fields across forms and search interfaces
  * Password fields now properly advance focus to the next field for improved form navigation
  * Search fields display the appropriate search action on the keyboard for better user experience
  * Optimized code organization for maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->