### PR TITLE
Login logout to home

### DIFF
--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -73,22 +73,20 @@ class _MainLayoutState extends State<MainLayout> {
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<AuthBloc, AuthBlocState>(
+      listenWhen: (previous, current) => previous.mode != current.mode,
       listener: (context, state) {
-        // Track when user has been logged in
+        // Route after login completes (works for both software and hardware wallets)
         if (state.mode == AuthorizeMode.logIn) {
           QuickLoginSwitch.trackUserLoggedIn();
-          // Always route to Wallet on login
           routingState.selectedMenu = MainMenuValue.wallet;
+          return;
         }
 
-        // Only reset the remember me dialog flag if user was logged in and is now logged out
-        // This prevents the flag from being reset on initial app startup
+        // Route after logout completes
         if (state.mode == AuthorizeMode.noLogin &&
             QuickLoginSwitch.hasBeenLoggedInThisSession) {
           routingState.resetOnLogOut();
-          // Reset dialog state so it can be shown again after user logs out
           QuickLoginSwitch.resetOnLogout();
-          // Always route to Wallet on logout
           routingState.selectedMenu = MainMenuValue.wallet;
         }
       },


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/3088

Though issue relates only to mobile, fix has been applied globally for consistency and UX.

To test:
- Go to settings page (or any page except the Wallet page)
- Create a wallet
- [ ] confirm after login, app navigates to Wallet page
- Go to settings page (or any page except the Wallet page)
- [ ] confirm after logout, app navigates to Wallet page
- Go to settings page (or any page except the Wallet page)
- Log in to an existing wallet
- [ ] confirm after login, app navigates to Wallet page
- Go to settings page (or any page except the Wallet page)
- [ ] confirm after logout, app navigates to Wallet page
- Go to settings page (or any page except the Wallet page)
- Log in to a hardware wallet
- [ ] confirm after login, app navigates to Wallet page
- Go to settings page (or any page except the Wallet page)
- [ ] confirm after logout, app navigates to Wallet page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File descriptor monitoring system to track and analyze system resource usage with real-time statistics
  * Start/stop monitoring with customizable intervals (default 60 seconds)
  * Query current file descriptor counts, limits, and usage percentages
  * Automatic detailed logging when thresholds are approached or on demand

<!-- end of auto-generated comment: release notes by coderabbit.ai -->