### PR TITLE
Fix comma decimal validation for russian locale

### DIFF
--- a/lib/bloc/fiat/fiat_repository.dart
+++ b/lib/bloc/fiat/fiat_repository.dart
@@ -5,6 +5,7 @@ import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/fiat/base_fiat_provider.dart';
 import 'package:web_dex/bloc/fiat/fiat_order_status.dart';
 import 'package:web_dex/bloc/fiat/models/models.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 
 class FiatRepository {
   FiatRepository(this.fiatProviders, this._coinsRepo);
@@ -136,7 +137,10 @@ class FiatRepository {
     }
 
     try {
-      final fiat = Decimal.parse(fiatAmount);
+      final fiat = parseLocaleAwareDecimal(fiatAmount);
+      if (fiat == null) {
+        throw FormatException('Invalid fiat amount');
+      }
 
       final coinAmount = fiat / spotPriceIncludingFee;
       return coinAmount.toDecimal(
@@ -185,7 +189,7 @@ class FiatRepository {
         return method.copyWith(
           priceInfo: method.priceInfo.copyWith(
             coinAmount: coinAmount,
-            fiatAmount: Decimal.tryParse(sourceAmount) ?? Decimal.zero,
+            fiatAmount: parseLocaleAwareDecimal(sourceAmount) ?? Decimal.zero,
           ),
         );
       }).toList();

--- a/lib/bloc/withdraw_form/withdraw_form_bloc.dart
+++ b/lib/bloc/withdraw_form/withdraw_form_bloc.dart
@@ -16,6 +16,7 @@ export 'package:web_dex/bloc/withdraw_form/withdraw_form_state.dart';
 export 'package:web_dex/bloc/withdraw_form/withdraw_form_step.dart';
 
 import 'package:decimal/decimal.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 
 class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
   final KomodoDefiSdk _sdk;
@@ -221,14 +222,15 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
     if (state.isMaxAmount) return;
 
     try {
-      final amount = Decimal.parse(event.amount);
+      final normalized = normalizeDecimalString(event.amount);
+      final amount = Decimal.parse(normalized);
       // Use the selected address balance if available
       final balance = state.selectedSourceAddress?.balance.spendable;
 
       if (balance != null && amount > balance) {
         emit(
           state.copyWith(
-            amount: event.amount,
+            amount: normalized,
             amountError: () => TextError(error: 'Insufficient funds'),
           ),
         );
@@ -238,7 +240,7 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
       if (amount <= Decimal.zero) {
         emit(
           state.copyWith(
-            amount: event.amount,
+            amount: normalized,
             amountError: () =>
                 TextError(error: 'Amount must be greater than 0'),
           ),
@@ -248,7 +250,7 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
 
       emit(
         state.copyWith(
-          amount: event.amount,
+          amount: normalized,
           amountError: () => null,
           previewError: () => null,
         ),
@@ -256,7 +258,7 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
     } catch (e) {
       emit(
         state.copyWith(
-          amount: event.amount,
+          amount: normalizeDecimalString(event.amount),
           amountError: () => TextError(error: 'Invalid amount'),
         ),
       );

--- a/lib/bloc/withdraw_form/withdraw_form_state.dart
+++ b/lib/bloc/withdraw_form/withdraw_form_state.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:web_dex/bloc/withdraw_form/withdraw_form_step.dart';
 import 'package:web_dex/model/text_error.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 
 class WithdrawFormState extends Equatable {
   final Asset asset;
@@ -69,13 +70,9 @@ class WithdrawFormState extends Equatable {
 
     // Amount must be greater than zero unless max amount is selected
     if (!isMaxAmount) {
-      try {
-        final parsedAmount = Decimal.parse(amount);
-        if (parsedAmount <= Decimal.zero) {
-          return false;
-        }
-      } catch (_) {
-        return false; // Invalid number format
+      final parsedAmount = parseLocaleAwareDecimal(amount);
+      if (parsedAmount == null || parsedAmount <= Decimal.zero) {
+        return false;
       }
     }
 
@@ -194,7 +191,7 @@ class WithdrawFormState extends Equatable {
     return WithdrawParameters(
       asset: asset.id.id,
       toAddress: recipientAddress,
-      amount: isMaxAmount ? null : Decimal.parse(amount),
+      amount: isMaxAmount ? null : parseLocaleAwareDecimal(amount),
       fee: isCustomFee ? customFee : null,
       from: selectedSourceAddress?.derivationPath != null
           ? WithdrawalSource.hdDerivationPath(

--- a/lib/model/forms/fiat/fiat_amount_input.dart
+++ b/lib/model/forms/fiat/fiat_amount_input.dart
@@ -1,5 +1,6 @@
 import 'package:decimal/decimal.dart';
 import 'package:formz/formz.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 
 /// Validation errors for the fiat amount form field.
 enum FiatAmountValidationError {
@@ -50,43 +51,4 @@ class FiatAmountInput extends FormzInput<String, FiatAmountValidationError> {
 
     return null;
   }
-}
-
-/// Normalizes and parses a decimal string value that might use different 
-/// locale formats
-// TODO: refactor into sdk or extension class for Decimal
-Decimal? parseLocaleAwareDecimal(String value) {
-  if (value.isEmpty) return null;
-
-  // First attempt: standard format with period as decimal separator (123.45)
-  // This covers standard format and numbers without thousand separators
-  final decimalValue = Decimal.tryParse(value);
-  if (decimalValue != null) return decimalValue;
-
-  // Second attempt: US/UK format with commas as thousand separators (1,234.56)
-  if (value.contains(',') && value.contains('.')) {
-    final normalizedValue = value.replaceAll(',', '');
-    final usFormat = Decimal.tryParse(normalizedValue);
-    if (usFormat != null) return usFormat;
-  }
-
-  // Third attempt: European format (1.234,56) or other edge cases
-  // Only try this if there's a comma and either no period or the period
-  // appears before the comma
-  if (value.contains(',')) {
-    final lastCommaIndex = value.lastIndexOf(',');
-    final lastPeriodIndex = value.lastIndexOf('.');
-
-    // Check if this looks like a European format number:
-    // - Has a comma
-    // - Either no period, or all periods appear before the last comma 
-    // (as thousand separators)
-    if (lastPeriodIndex == -1 || lastPeriodIndex < lastCommaIndex) {
-      final europeanFormat = value.replaceAll('.', '').replaceAll(',', '.');
-      final euFormat = Decimal.tryParse(europeanFormat);
-      if (euFormat != null) return euFormat;
-    }
-  }
-
-  return null;
 }

--- a/lib/model/forms/trade_margin_input.dart
+++ b/lib/model/forms/trade_margin_input.dart
@@ -1,4 +1,5 @@
 import 'package:formz/formz.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 
 enum TradeMarginValidationError {
   /// Input is empty
@@ -23,7 +24,7 @@ class TradeMarginInput extends FormzInput<String, TradeMarginValidationError> {
   const TradeMarginInput.dirty(String value, {this.min = 0, this.max = 1000})
       : super.dirty(value);
 
-  double get valueAsDouble => double.tryParse(value) ?? 0;
+  double get valueAsDouble => tryParseLocaleAwareDouble(value) ?? 0;
 
   @override
   TradeMarginValidationError? validator(String value) {
@@ -31,7 +32,7 @@ class TradeMarginInput extends FormzInput<String, TradeMarginValidationError> {
       return TradeMarginValidationError.empty;
     }
 
-    final margin = double.tryParse(value);
+    final margin = tryParseLocaleAwareDouble(value);
     if (margin == null) {
       return TradeMarginValidationError.invalidNumber;
     }


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-adb19233-4bbb-42f4-97ba-245193160855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adb19233-4bbb-42f4-97ba-245193160855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce locale-aware decimal normalization/parsing and use it for fiat amounts, trade margin, and withdrawal amount handling/validation.
> 
> - **Utils**:
>   - Add `normalizeDecimalString`, `parseLocaleAwareDecimal`, and `tryParseLocaleAwareDouble` in `shared/utils/formatters.dart` for locale-aware number handling.
> - **Withdraw Flow**:
>   - `WithdrawFormBloc._onAmountChanged` now normalizes input (`normalizeDecimalString`) and parses with `Decimal.parse(normalized)`.
>   - `WithdrawFormState` validation uses `parseLocaleAwareDecimal`; `toWithdrawParameters` passes parsed `amount` or `null` when max.
> - **Fiat Buy Flow**:
>   - `FiatRepository` uses `parseLocaleAwareDecimal` in `_calculateCoinAmount` and when setting `priceInfo.fiatAmount` for estimates.
> - **Forms**:
>   - `FiatAmountInput` and `TradeMarginInput` use `parseLocaleAwareDecimal` / `tryParseLocaleAwareDouble` for validation and value access.
>   - Remove inline locale-aware decimal parser from `fiat_amount_input.dart` in favor of shared utils.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf97715055a087100fd95848043a762bcd99270. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->