### PR TITLE
Add csp flag to flutter web builds

### DIFF
--- a/.docker/build.sh
+++ b/.docker/build.sh
@@ -113,8 +113,8 @@ else
 fi
 # Add web-specific build arguments if the target is web
 if [ "$BUILD_TARGET" = "web" ]; then
-    echo "Adding web-specific build arguments: --no-web-resources-cdn"
-    BUILD_CMD="$BUILD_CMD --no-web-resources-cdn"
+    echo "Adding web-specific build arguments: --csp --no-web-resources-cdn"
+    BUILD_CMD="$BUILD_CMD --csp --no-web-resources-cdn"
 fi
 # Use the provided arguments for flutter build
 # Build a second time if needed, as asset downloads will require a rebuild on the first attempt

--- a/.github/actions/generate-assets/action.yml
+++ b/.github/actions/generate-assets/action.yml
@@ -8,7 +8,7 @@ inputs:
   BUILD_COMMAND:
     description: "The flutter build command to run to generate assets for the deployment build"
     required: false
-    default: "flutter build web --no-pub --release"
+    default: "flutter build web --csp --no-pub --release"
 
   # Optional Trello feedback provider configuration
   TRELLO_API_KEY:

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -80,7 +80,7 @@ flutter pub get --enforce-lockfile
 pushd macos; pod deintegrate; pod install; popd    # Generating Pods project
 
 # 2. Fetch all required artifacts (this runs komodo_wallet_build_transformer)
-flutter build web --no-pub -v
+flutter build web --csp --no-pub -v
 
 # 3. Build the macOS release application (ensure --flavor production is present)
 flutter build macos --no-pub --release -v \

--- a/docs/BUILD_RELEASE.md
+++ b/docs/BUILD_RELEASE.md
@@ -63,7 +63,7 @@ docker build -f .docker/android-sdk.dockerfile . -t komodo/android-sdk:34
 docker build -f .docker/komodo-wallet-android.dockerfile . -t komodo/komodo-wallet
 # Build the app
 mkdir -p build
-docker run --rm -v ./build:/app/build komodo/komodo-wallet:latest bash -c "flutter pub get --enforce-lockfile && flutter build web --no-pub --release"
+docker run --rm -v ./build:/app/build komodo/komodo-wallet:latest bash -c "flutter pub get --enforce-lockfile && flutter build web --csp --no-pub --release"
 ```
 
 ### Build for Android

--- a/docs/BUILD_SECURITY_ADVISORY.md
+++ b/docs/BUILD_SECURITY_ADVISORY.md
@@ -7,6 +7,7 @@ When building the Komodo Wallet for production, **always** use the following fla
 ```bash
 --enforce-lockfile  # When running 'flutter pub get'
 --no-pub            # When running 'flutter build'
+--csp               # When building for web (required for event streaming worker)
 --no-web-resources-cdn  # When building for web
 ```
 
@@ -45,6 +46,17 @@ This flag prevents Flutter from using Google-hosted CDNs for engine resources wh
 - **Improves privacy**: Prevents user browsers from making connections to third-party servers when using the application.
 - **Guarantees availability**: Application will function even if external CDNs become unavailable or are blocked in certain regions.
 - **Simplifies security audits**: All resources are contained within your deployment, making the security perimeter clearer.
+
+### `--csp`
+
+This flag enables Content Security Policy (CSP) compatibility mode for Flutter web builds.
+
+**Why this matters:**
+
+- **Required for Web Workers**: The event streaming worker (SharedWorker/Worker) requires CSP-compatible code generation to function properly.
+- **Enhanced security**: CSP-compatible builds generate code that works with strict Content Security Policy headers, preventing inline script execution.
+- **Browser compatibility**: Ensures the application functions correctly in environments with strict CSP policies.
+- **Future-proofing**: As browsers and security standards evolve, CSP compliance becomes increasingly important for web applications.
 
 ## Implementation Recommendations
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-afca213e-0e0a-419a-a4a9-75beb9df02eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afca213e-0e0a-419a-a4a9-75beb9df02eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--csp` to Flutter web builds across scripts, CI action defaults, and documentation, with security advisory updates.
> 
> - **Build scripts**:
>   - Update `.docker/build.sh` to include `--csp` for web builds alongside `--no-web-resources-cdn`.
> - **CI/GitHub Actions**:
>   - Change default `BUILD_COMMAND` in `.github/actions/generate-assets/action.yml` to `flutter build web --csp --no-pub --release`.
> - **Documentation**:
>   - `contrib/README.md`, `docs/BUILD_RELEASE.md`: Replace web build commands to use `--csp`.
>   - `docs/BUILD_SECURITY_ADVISORY.md`: Add `--csp` to required flags and include a justification section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2c36d61a120df19c55fd786eb8da4f142d3ddea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->