### PR TITLE
fix(dex): surface best_orders failures; CTA to Maker; localized empty states

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -507,6 +507,8 @@
   "orderBookNoAsks": "No asks found",
   "orderBookNoBids": "No bids found",
   "orderBookEmpty": "Orderbook is empty",
+  "dexNoSwapOffers": "No swap offers available for the selected asset.",
+  "bridgeNoCrossNetworkRoutes": "No cross-network routes found for this asset.",
   "freshAddress": "Fresh address",
   "userActionRequired": "User action required",
   "unknown": "Unknown",

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -44,6 +44,11 @@ const Duration kPerformanceLogInterval = Duration(minutes: 1);
 /// - Balance and price update polling
 const bool kDebugElectrumLogs = true;
 
+/// Temporary failure simulation toggles for testing UI/flows.
+/// Guarded by kDebugMode in calling sites.
+const bool kSimulateBestOrdersFailure = false;
+const double kSimulatedBestOrdersFailureRate = 0.5; // 50%
+
 // This information is here because it is not contextual and is branded.
 // Names of their own are not localized. Also, the application is initialized before
 // the localization package is initialized.

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -503,6 +503,8 @@ abstract class  LocaleKeys {
   static const orderBookNoAsks = 'orderBookNoAsks';
   static const orderBookNoBids = 'orderBookNoBids';
   static const orderBookEmpty = 'orderBookEmpty';
+  static const dexNoSwapOffers = 'dexNoSwapOffers';
+  static const bridgeNoCrossNetworkRoutes = 'bridgeNoCrossNetworkRoutes';
   static const freshAddress = 'freshAddress';
   static const userActionRequired = 'userActionRequired';
   static const unknown = 'unknown';

--- a/lib/views/bridge/view/table/bridge_nothing_found.dart
+++ b/lib/views/bridge/view/table/bridge_nothing_found.dart
@@ -1,18 +1,38 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/router/state/routing_state.dart';
+import 'package:web_dex/model/main_menu_value.dart';
 
 class BridgeNothingFound extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.fromLTRB(0, 30, 0, 20),
-      child: Row(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text(
-            LocaleKeys.nothingFound.tr(),
-            style: Theme.of(context).textTheme.bodySmall,
+              Text(
+                LocaleKeys.bridgeNoCrossNetworkRoutes.tr(),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          UiSimpleButton(
+            onPressed: () {
+              routingState.selectedMenu = MainMenuValue.dex;
+              routingState.dexState.orderType = 'maker';
+            },
+            child: Text(
+              LocaleKeys.makerOrder.tr(),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
           ),
         ],
       ),

--- a/lib/views/dex/simple/form/tables/orders_table/orders_table_content.dart
+++ b/lib/views/dex/simple/form/tables/orders_table/orders_table_content.dart
@@ -11,10 +11,11 @@ import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/base.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/best_orders/best_orders.dart';
 import 'package:web_dex/model/authorize_mode.dart';
-import 'package:web_dex/views/dex/simple/form/tables/nothing_found.dart';
 import 'package:web_dex/views/dex/simple/form/tables/orders_table/grouped_list_view.dart';
 import 'package:web_dex/views/dex/simple/form/tables/table_utils.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/router/state/routing_state.dart';
+import 'package:web_dex/model/main_menu_value.dart';
 
 class OrdersTableContent extends StatelessWidget {
   const OrdersTableContent({
@@ -61,7 +62,9 @@ class OrdersTableContent extends StatelessWidget {
                   .testCoinsEnabled,
             );
 
-            if (orders.isEmpty) return const NothingFound();
+            if (orders.isEmpty) {
+              return const _NoOrdersCta();
+            }
 
             return GroupedListView<BestOrder>(
               items: orders,
@@ -110,6 +113,40 @@ class _ErrorMessage extends StatelessWidget {
                     context.read<TakerBloc>().add(TakerUpdateBestOrders()),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoOrdersCta extends StatelessWidget {
+  const _NoOrdersCta();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 30, 12, 20),
+      alignment: const Alignment(0, 0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            LocaleKeys.dexNoSwapOffers.tr(),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          UiSimpleButton(
+            child: Text(
+              // Reuse existing localization for Maker order label
+              LocaleKeys.makerOrder.tr(),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            onPressed: () {
+              routingState.selectedMenu = MainMenuValue.dex;
+              routingState.dexState.orderType = 'maker';
+            },
           ),
         ],
       ),


### PR DESCRIPTION
This PR addresses best_orders error handling and improves UX for empty orderbooks.

### Changes
- Propagate best_orders failures (no longer masked as empty).
- Map P2P "No response from any peer" (including wrapped Exception text) to "no orders" so the UI shows an empty state instead of an error.
- Add debug-only failure simulator gated by `app_config.dart` toggles (`kSimulateBestOrdersFailure`, rate configurable).
- Taker: show CTA to create a Maker order when no swap offers are available.
- Bridge: show CTA when no cross-network routes are available.
- Add locale keys: `dexNoSwapOffers`, `bridgeNoCrossNetworkRoutes` and wire them in the UI.

### Other
- Keep `best_orders` disabled outside Swap/Bridge pages.
- Maintain retry logic already present in `Mm2Api`.

### Screenshots
<img width="553" height="628" alt="image" src="https://github.com/user-attachments/assets/3622963a-b972-4dfe-ac83-9a73b4428514" />
<img width="546" height="531" alt="image" src="https://github.com/user-attachments/assets/a30e9d46-27ef-424d-b13b-9a420a4a0582" />



### NB!
Disable the failure simulator before merge.

Please review error mapping and copy.
