### PR TITLE
fix(trading-bot): accurate min volume, clearer errors, and resilient preimage fetching

### DIFF
--- a/lib/bloc/market_maker_bot/market_maker_trade_form/market_maker_trade_form_state.dart
+++ b/lib/bloc/market_maker_bot/market_maker_trade_form/market_maker_trade_form_state.dart
@@ -32,6 +32,8 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
     this.tradePreImageError,
     this.tradePreImage,
     this.maxMakerVolume,
+    this.minTradingVolume,
+    this.rawErrorMessage,
     this.isLoadingMaxMakerVolume = false,
   });
 
@@ -49,6 +51,8 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
       tradePreImageError = null,
       tradePreImage = null,
       maxMakerVolume = null,
+      minTradingVolume = null,
+      rawErrorMessage = null,
       isLoadingMaxMakerVolume = false;
 
   /// The coin being sold in the trade pair (base coin).
@@ -92,6 +96,15 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
   /// The maximum maker volume available for swaps for the sell coin.
   /// This value is fetched from the DEX API and cached in the state.
   final Rational? maxMakerVolume;
+
+  /// The minimum trading volume required by the base coin (sell coin).
+  /// Retrieved from the DEX API `min_trading_vol` for clearer validation
+  /// and error messaging.
+  final Rational? minTradingVolume;
+
+  /// Raw error message for displaying unparsed backend errors to users when
+  /// a generic/transport failure persists after retries.
+  final String? rawErrorMessage;
 
   /// Indicates whether the max maker volume is currently being fetched.
   final bool isLoadingMaxMakerVolume;
@@ -172,6 +185,8 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
     MarketMakerTradeFormStage? stage,
     TradePreimage? tradePreImage,
     Rational? maxMakerVolume,
+    Rational? minTradingVolume,
+    String? rawErrorMessage,
     bool? isLoadingMaxMakerVolume,
   }) {
     return MarketMakerTradeFormState(
@@ -188,6 +203,8 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
       stage: stage ?? this.stage,
       tradePreImage: tradePreImage ?? this.tradePreImage,
       maxMakerVolume: maxMakerVolume ?? this.maxMakerVolume,
+      minTradingVolume: minTradingVolume ?? this.minTradingVolume,
+      rawErrorMessage: rawErrorMessage ?? this.rawErrorMessage,
       isLoadingMaxMakerVolume:
           isLoadingMaxMakerVolume ?? this.isLoadingMaxMakerVolume,
     );
@@ -244,6 +261,8 @@ class MarketMakerTradeFormState extends Equatable with FormzMixin {
     status,
     tradePreImage,
     maxMakerVolume,
+    minTradingVolume,
+    rawErrorMessage,
     isLoadingMaxMakerVolume,
   ];
 }

--- a/lib/views/market_maker_bot/market_maker_bot_confirmation_form.dart
+++ b/lib/views/market_maker_bot/market_maker_bot_confirmation_form.dart
@@ -133,10 +133,11 @@ class _MarketMakerBotConfirmationFormState
                 TotalFees(preimage: state.tradePreImage),
                 const SizedBox(height: 24),
                 SwapErrorMessage(
-                  errorMessage: state.tradePreImageError?.text(
-                    state.sellCoin.value,
-                    state.buyCoin.value,
-                  ),
+                  errorMessage: state.rawErrorMessage ??
+                      state.tradePreImageError?.text(
+                        state.sellCoin.value,
+                        state.buyCoin.value,
+                      ),
                   context: context,
                 ),
                 Flexible(

--- a/lib/views/market_maker_bot/market_maker_bot_form_content.dart
+++ b/lib/views/market_maker_bot/market_maker_bot_form_content.dart
@@ -131,10 +131,10 @@ class _MarketMakerBotFormContentState extends State<MarketMakerBotFormContent> {
                   const SizedBox(height: 12),
                   if (state.tradePreImageError != null)
                     ImportantNote(
-                      text:
-                          state.tradePreImageError?.text(
+                      text: state.tradePreImageError?.textWithMin(
                             state.sellCoin.value,
                             state.buyCoin.value,
+                            state.minTradingVolume?.toString(),
                           ) ??
                           '',
                     ),

--- a/lib/views/market_maker_bot/market_maker_form_error_message_extensions.dart
+++ b/lib/views/market_maker_bot/market_maker_form_error_message_extensions.dart
@@ -68,7 +68,8 @@ extension AmountValidationErrorText on AmountValidationError {
         return LocaleKeys.dexInsufficientFundsError
             .tr(args: [balance.toString(), coin?.abbr ?? '']);
       case AmountValidationError.lessThanMinimum:
-        return LocaleKeys.mmBotMinimumTradeVolume.tr(args: ["0.00000001"]);
+        return LocaleKeys.mmBotMinimumTradeVolume
+            .tr(args: ["0.00000001 ${coin?.abbr ?? ''}"]);
     }
   }
 }
@@ -93,9 +94,27 @@ extension MarketMakerTradeFormErrorText on MarketMakerTradeFormError {
         return LocaleKeys.withdrawNotEnoughBalanceForGasError
             .tr(args: [relCoin?.parentCoin?.abbr ?? relCoin?.abbr ?? '']);
       case MarketMakerTradeFormError.insufficientTradeAmount:
-        return LocaleKeys.mmBotMinimumTradeVolume.tr(args: ["0.00000001"]);
+        return LocaleKeys.mmBotMinimumTradeVolume
+            .tr(args: ["too low for ${baseCoin?.abbr ?? ''}"]);
       default:
         return LocaleKeys.dexErrorMessage.tr();
     }
+  }
+}
+
+extension MarketMakerTradeFormErrorTextWithMin on MarketMakerTradeFormError {
+  String textWithMin(
+    Coin? baseCoin,
+    Coin? relCoin,
+    String? minTradingVolume,
+  ) {
+    if (this == MarketMakerTradeFormError.insufficientTradeAmount) {
+      final ticker = baseCoin?.abbr ?? '';
+      final minText = (minTradingVolume?.isNotEmpty ?? false)
+          ? minTradingVolume
+          : 'too low for';
+      return LocaleKeys.mmBotMinimumTradeVolume.tr(args: ['$minText $ticker']);
+    }
+    return text(baseCoin, relCoin);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/KomodoPlatform/komodo-wallet/pull/3300#pullrequestreview-3403609990

---

This PR addresses misleading minimum-volume messaging and intermittent `trade_preimage` transport errors in the Market Maker bot flow. It improves correctness, UX, and observability.

### What changed

- Accurate minimum trading volume in UI
  - Fetch base coin minimum from `min_trading_vol` (via `DexRepository.getMinTradingVolume`) and show it with the coin ticker instead of a hardcoded placeholder.
  - Reference: [KDF min_trading_vol docs](https://komodoplatform.com/en/docs/komodo-defi-framework/api/legacy/min_trading_vol/).

- Error classification fixes
  - Map `TradePreimageVolumeTooLowError` → show "Minimum trade volume is … <TICKER>".
  - Stop mapping `TradePreimageTransportError` to min-volume; it's now treated separately (see retry logic below).

- Transport error retry with spinner + raw fallback
  - On `TradePreimageTransportError`, retry `trade_preimage` every 1s up to 10 seconds.
  - While retrying, the confirmation screen shows a spinner (`MarketMakerTradeFormStatus.loading`).
  - If it still fails after retries, we surface the raw backend error text in the confirmation UI.
  - We log each retry attempt for troubleshooting.

- State additions
  - `MarketMakerTradeFormState.minTradingVolume` to store coin-specific minimum.
  - `MarketMakerTradeFormState.rawErrorMessage` to display unparsed backend errors when retries exhaust.

### Files of interest

- `lib/bloc/market_maker_bot/market_maker_trade_form/market_maker_trade_form_bloc.dart`
  - Fetch `min_trading_vol` when base coin changes / coins are swapped / order is edited.
  - Add retry loop for `TradePreimageTransportError` (10 attempts, 1s apart) with logging.
  - After retries, emit `status=error` and set `rawErrorMessage` for UI display.
  - Map errors: `VolumeTooLow` → min-volume error; `Transport` → not misclassified.

- `lib/bloc/market_maker_bot/market_maker_trade_form/market_maker_trade_form_state.dart`
  - Add `minTradingVolume` and `rawErrorMessage` fields; include in `copyWith` and `props`.

- `lib/views/market_maker_bot/market_maker_bot_confirmation_form.dart`
  - Show spinner when `status == loading` (existing).
  - Prefer `rawErrorMessage` when present; otherwise derive UI-friendly text from error type.

- `lib/views/market_maker_bot/market_maker_form_error_message_extensions.dart`
  - Append ticker to minimum-volume messages.
  - New helper `textWithMin` that uses fetched `min_trading_vol` where available.

### UX before vs after

- Before
  - Hardcoded "Minimum trade volume is 0.00000001" regardless of coin.
  - Intermittent network/transport failures were shown as min-volume errors.

- After
  - Shows real minimum (e.g., "Minimum trade volume is 1/10000 KMD").
  - On transport errors: spinner → 10s retry → raw error if still failing.

### How to test

1) Minimum volume display
   - Select a base coin (e.g., KMD). Trigger preview (Proceed to confirmation).
   - Ensure ImportantNote shows real coin minimum with ticker (e.g., `1/10000 KMD`).

2) Volume-too-low path
   - Enter sell amount below the coin minimum and preview.
   - Expect minimum-volume error message; no spinner after the response returns.

3) Transport error path
   - Simulate network hiccup (e.g., block RPC call or temporarily disconnect).
   - Trigger preview: spinner appears; logs show retry attempts 1..10.
   - After ~10s, expect raw backend error message to be displayed.

### Notes / Risk

- The retry loop is bounded (10 attempts, 1s), so UX remains predictable.
- We only log warnings on retries; no stack traces unless the call throws.
- This PR does not change order posting; it only impacts preview and the bot setup form.

