### PR TITLE
disable NFT page in sidebar menu

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -750,6 +750,7 @@
   "trend7d": "7d trend",
   "tradingDisabledTooltip": "Trading features are currently disabled",
   "tradingDisabled": "Trading unavailable in your location",
+  "nftDisabledTooltip": "NFT functionality is currently disabled. Improvements are on the way!",
   "includeBlockedAssets": "Include blocked assets",
   "unbanPubkeysResults": "Unban Pubkeys Results",
   "unbannedPubkeys": {

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -744,6 +744,7 @@ abstract class  LocaleKeys {
   static const trend7d = 'trend7d';
   static const tradingDisabledTooltip = 'tradingDisabledTooltip';
   static const tradingDisabled = 'tradingDisabled';
+  static const nftDisabledTooltip = 'nftDisabledTooltip';
   static const includeBlockedAssets = 'includeBlockedAssets';
   static const unbanPubkeysResults = 'unbanPubkeysResults';
   static const unbannedPubkeys = 'unbannedPubkeys';

--- a/lib/views/common/main_menu/main_menu_bar_mobile.dart
+++ b/lib/views/common/main_menu/main_menu_bar_mobile.dart
@@ -94,10 +94,13 @@ class MainMenuBarMobile extends StatelessWidget {
                       ),
                     ),
                   Expanded(
-                    child: MainMenuBarMobileItem(
-                      value: MainMenuValue.nft,
-                      enabled: currentWallet?.isHW != true,
-                      isActive: selected == MainMenuValue.nft,
+                    child: Tooltip(
+                      message: LocaleKeys.nftDisabledTooltip.tr(),
+                      child: MainMenuBarMobileItem(
+                        value: MainMenuValue.nft,
+                        enabled: false,
+                        isActive: selected == MainMenuValue.nft,
+                      ),
                     ),
                   ),
                   Expanded(

--- a/lib/views/common/main_menu/main_menu_desktop.dart
+++ b/lib/views/common/main_menu/main_menu_desktop.dart
@@ -135,12 +135,16 @@ class _MainMenuDesktopState extends State<MainMenuDesktop> {
                                   ),
                                 ),
                               ),
-                            DesktopMenuDesktopItem(
-                              key: const Key('main-menu-nft'),
-                              enabled: currentWallet?.isHW != true,
-                              menu: MainMenuValue.nft,
-                              onTap: onTapItem,
-                              isSelected: _checkSelectedItem(MainMenuValue.nft),
+                            Tooltip(
+                              message: LocaleKeys.nftDisabledTooltip.tr(),
+                              child: DesktopMenuDesktopItem(
+                                key: const Key('main-menu-nft'),
+                                enabled: false,
+                                menu: MainMenuValue.nft,
+                                onTap: onTapItem,
+                                isSelected:
+                                    _checkSelectedItem(MainMenuValue.nft),
+                              ),
                             ),
                             const Spacer(),
                             Divider(thickness: 1),


### PR DESCRIPTION
closes: https://github.com/KomodoPlatform/komodo-wallet/issues/3361

To test:
- launch
- mouseover NFT button in sidebar
- see tooltip
- experience no action on click
- login
- repeat mouseover tooltip and click check