### PR TITLE
bypass ARRR autoactivation if sync params have not previously set

### DIFF
--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -374,6 +374,21 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
     final selectedCoinIds = result.map((c) => c.id.id).toSet();
 
     for (final walletCoin in walletCoins) {
+      // Do not pre-select ZHTLC coins without saved configuration.
+      // This ensures toggles remain OFF if auto-activation was bypassed.
+      if (walletCoin.id.subClass == CoinSubClass.zhtlc) {
+        try {
+          final saved =
+              await _sdk.activationConfigService.getSavedZhtlc(walletCoin.id);
+          if (saved == null) {
+            continue;
+          }
+        } catch (_) {
+          // On any error, be conservative and keep toggle OFF
+          continue;
+        }
+      }
+
       if (!selectedCoinIds.contains(walletCoin.id.id)) {
         result.add(walletCoin);
       }


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet/issues/3369

The issue case is edge, but I've confirmed the phone/wallet I was having consistent issues with was resolved by these changes. Subsequent selection of ARRR for activation was successful.

Changes:
- adds a bypass to remove ZHTLC coins from the auto-activate list if sync params have not previously been set
- avoids sync params dialog appearing upon login (which led to the crash)

