### PR TITLE
fix(web): eliminate blank screen during loading overlay transition

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -370,20 +370,24 @@ class _MyAppViewState extends State<_MyAppView> {
   // web and native to avoid web-code in code concerning all platforms.
   Future<void> _hideAppLoader() async {
     if (kIsWeb) {
-      html.document.getElementById('main-content')?.style.display = 'block';
+      // Duration must match the CSS transition/animation in index.html
+      const animationDurationMs = 330;
 
       final loadingElement = html.document.getElementById('loading');
+      final mainContent = html.document.getElementById('main-content');
 
-      if (loadingElement == null) return;
+      // Fade in main content and fade out loader simultaneously for smooth
+      // crossfade (avoids brief blank screen between loader and app).
+      mainContent?.style.opacity = '1';
+      loadingElement?.classes.add('init_done');
 
-      // Trigger the zoom out animation.
-      loadingElement.classes.add('init_done');
-
-      // Await 200ms so the user can see the animation.
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      // Wait for both animations to complete before removing the loader.
+      await Future<void>.delayed(
+        const Duration(milliseconds: animationDurationMs),
+      );
 
       // Remove the loading indicator.
-      loadingElement.remove();
+      loadingElement?.remove();
 
       final delay = DateTime.now()
           .difference(_pageLoadStartTime)
@@ -392,7 +396,7 @@ class _MyAppViewState extends State<_MyAppView> {
         PageInteractiveDelayEventData(
           pageName: 'app_root',
           interactiveDelayMs: delay,
-          spinnerTimeMs: 200,
+          spinnerTimeMs: animationDurationMs,
         ),
       );
     }

--- a/web/index.html
+++ b/web/index.html
@@ -142,7 +142,8 @@
     <script
         async="false">window.addEventListener("DOMContentLoaded", (d => { console.log("DOM fully loaded and parsed"), window.init_wasm && !0 !== window.is_mm2_preload_busy && (window.is_mm2_preload_busy = !0, window.init_wasm().then((() => { window.is_mm2_preloaded = !0 })).finally((() => { window.is_mm2_preload_busy = !1 }))) }))</script>
     <!-- App -->
-    <div id="main-content" style="position:absolute;width:100%;height:100%;display:none">
+    <div id="main-content"
+        style="position:absolute;width:100%;height:100%;opacity:0;transition:opacity .33s ease-in-out">
         <!-- Flutter app will be injected here -->
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Fix the brief blank screen that appeared after the loading overlay animated out but before the Flutter app content was visible
- Use opacity crossfade instead of `display: none/block` toggle for smooth transition
- Main content now fades in simultaneously as the loader fades out
- Aligned wait duration (330ms) to match actual CSS animation timing

## Test plan
- [ ] Load the web app and verify smooth transition from loading overlay to app content
- [ ] Confirm no blank/white flash occurs during the transition
- [ ] Test on both light and dark themes