### PR TITLE
feat(branding): add GleecDEX logo widget with Rubik font

### DIFF
--- a/lib/shared/widgets/gleec_dex_logo.dart
+++ b/lib/shared/widgets/gleec_dex_logo.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show FontVariation;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:web_dex/app_config/app_config.dart';
@@ -10,26 +12,40 @@ const Color gleecPurple = Color(0xFF8C41FF);
 /// - "GLEEC" wordmark (theme-aware color)
 /// - "DEX" text in purple
 class GleecDexLogo extends StatelessWidget {
-  const GleecDexLogo({super.key, this.height = 32, this.forceThemeMode});
+  const GleecDexLogo({
+    super.key,
+    this.height = 32,
+    this.themeMode,
+    this.isDense = false,
+  });
 
   /// The height of the logo. Width scales proportionally.
   final double height;
 
   /// If set, forces the logo to display in the specified theme mode
   /// regardless of the current app theme. Useful for theme previews.
-  final ThemeMode? forceThemeMode;
+  final ThemeMode? themeMode;
+
+  /// If true, uses tighter spacing between elements.
+  final bool isDense;
 
   @override
   Widget build(BuildContext context) {
     // Calculate proportional sizes based on height
-    // Icon and text should be the same visual height (matching GLEEC BTC style)
-    final double textHeight = height * 0.6;
+    final double textHeight = height * 0.55;
     final double iconSize = height;
-    final double spacing = height * 0.3;
 
+    // Spacing tweaks (based on current-state comparison to BTC reference):
+    // - icon → GLEEC gap: +~12%
+    // - GLEEC → DEX gap: keep as-is
+    final double iconTextSpacingBase = isDense ? 13.0 : 17.4;
+    final double iconTextSpacing = iconTextSpacingBase * 1.12;
+
+    final double wordmarkDexSpacing = isDense ? 5.0 : 7.4;
+    final double letterSpacing = textHeight * (isDense ? 0.058 : 0.060);
     // Determine if we should use dark theme styling
-    final bool isDarkTheme = forceThemeMode != null
-        ? forceThemeMode == ThemeMode.dark
+    final bool isDarkTheme = themeMode != null
+        ? themeMode == ThemeMode.dark
         : Theme.of(context).brightness == Brightness.dark;
 
     final String themePostfix = isDarkTheme ? '_dark' : '';
@@ -48,25 +64,30 @@ class GleecDexLogo extends StatelessWidget {
             width: iconSize,
             height: iconSize,
           ),
-          SizedBox(width: spacing),
+          SizedBox(width: iconTextSpacing),
+
           // GLEEC wordmark (theme-aware)
           SvgPicture.asset(
             '$assetsPath/logo/logo$themePostfix.svg',
             height: textHeight,
           ),
-          SizedBox(width: spacing * 0.75),
+          SizedBox(width: wordmarkDexSpacing),
+
+          // Small offset to align DEX baseline with GLEEC wordmark
           Transform.translate(
-            offset: Offset(0, textHeight * 0.25),
+            offset: Offset(0, textHeight * 0.08),
             child: Text(
               'DEX',
-              strutStyle: const StrutStyle(height: 1.0, forceStrutHeight: true),
               style: TextStyle(
                 fontFamily: 'Rubik',
-                fontSize: textHeight * 1.32,
-                fontVariations: const [
-                  FontVariation('wght', 600),
-                ], // Use this for variable fonts
-                letterSpacing: textHeight * 0.09,
+                fontSize: textHeight * 1.43,
+
+                // Reduce perceived weight (DEX was reading heavier than BTC suffix)
+                fontVariations: const [FontVariation('wght', 450)],
+
+                // Slight tracking bump helps soften perceived heaviness (esp. in purple)
+                letterSpacing: letterSpacing,
+
                 color: gleecPurple,
                 height: 1.0,
               ),

--- a/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
+++ b/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
@@ -79,9 +79,7 @@ class _SettingsModeSelector extends StatelessWidget {
               right: 8,
               top: 0,
               bottom: 0,
-              child: Center(
-                child: GleecDexLogo(height: 20, forceThemeMode: mode),
-              ),
+              child: Center(child: GleecDexLogo(height: 20, themeMode: mode)),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),


### PR DESCRIPTION
## Summary

Adds a new `GleecDexLogo` widget for consistent GLEEC DEX branding throughout the app.

Before:
<img width="280" height="120" alt="image" src="https://github.com/user-attachments/assets/f3dcb06f-7797-484d-aeb8-fb1896ec9197" />

After:
<img width="245" height="75" alt="image" src="https://github.com/user-attachments/assets/9a9019a1-a1bb-47a6-b1fd-55f3e0933b2a" />



## Changes

- Add Rubik variable font asset for DEX text styling
- Create `GleecDexLogo` widget with theme-aware coloring
- Add logo assets (dark/light variants)
- Integrate logo in theme switcher preview
- Refine spacing and font weight for visual balance matching BTC reference

## Features

- Responsive sizing based on height prop
- Theme-aware colors (light/dark mode)
- Dense mode option for compact layouts
- Uses Rubik variable font with configurable weight