### PR TITLE
chore(release): prepare 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# Gleec Wallet v0.9.5 Release Notes
+
+This release prepares the updated `0.9.4` release line for mobile publishing as `0.9.5`, keeping the web release history intact while integrating the final mobile-readiness SDK roll. Highlights include `komodo-defi-sdk v0.6.0`, legacy wallet migration support, hardened TRON/TRC20 and SIA handling, refreshed Gleec Dex branding, and release metadata/lockfile updates for reproducible native builds.
+
+## 🚀 New Features
+
+- **SDK 0.6.0 Integration** ([@CharlVS]) - Roll the SDK submodule to the published `komodo-defi-sdk v0.6.0` release, bringing the finalized mobile-readiness package set into the app.
+- **Legacy Wallet Migration Support** ([@CharlVS]) - Include the SDK-side migration package and auth/framework hooks for discovering, verifying, importing, and cleaning up legacy wallet data.
+- **TRON/TRC20 and SIA Readiness** ([@CharlVS]) - Pull in hardened TRON activation, transaction-history, explorer, and market-data handling alongside the finalized SIA activation and withdrawal strategy.
+
+## 🐛 Bug Fixes
+
+- **Balance, Fee, and Market Data Hardening** ([@CharlVS]) - Integrate SDK fixes for activation recovery, richer fee information, cached spot-price continuity, CoinGecko failure cooldowns, and numeric JSON compatibility.
+- **Gleec Dex Branding Refresh** ([@CharlVS], #3479) - Preserve the updated Gleec Dex title, app metadata, icons, social preview assets, and Ramp logo cache-busting changes already prepared on `dev`.
+- **Web Publishing Adjustment** ([@DeckerSU], #3476) - Keep the non-WASM web build path adjustment from `dev` so web publishing remains aligned with the current deployment target.
+
+## 🔧 Technical Improvements
+
+- **Release Metadata Refresh** ([@CharlVS]) - Move the app release name to `0.9.5+0` and refresh dependency resolution against the SDK `0.6.0` submodule.
+
+**Full Changelog**: [0.9.4...0.9.5](https://github.com/GLEECBTC/gleec-wallet/compare/0.9.4...0.9.5)
+
+---
+
 # Gleec Wallet v0.9.4 Release Notes
 
 This release packages the current `dev` branch work for the next `main` update with broader asset support, a stronger web runtime, and a much larger polish pass across the wallet. Highlights include TRON and SIA flows on top of `komodo-defi-sdk v0.5.0`, Flutter Web WASM support, runtime-loaded legal documents, refreshed wallet and trading surfaces, and the QA/release infrastructure that came out of the documented polish program.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -704,70 +704,70 @@ packages:
       path: "sdk/packages/komodo_cex_market_data"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.0+1"
   komodo_coin_updates:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coin_updates"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   komodo_coins:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coins"
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.3.2+1"
   komodo_defi_framework:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_framework"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   komodo_defi_local_auth:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_local_auth"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   komodo_defi_rpc_methods:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_rpc_methods"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   komodo_defi_sdk:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_sdk"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
   komodo_defi_types:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_types"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   komodo_ui:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_ui"
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.3.2"
   komodo_wallet_build_transformer:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_wallet_build_transformer"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.9.4+0
+version: 0.9.5+0
 
 environment:
   sdk: ">=3.8.1 <4.0.0"


### PR DESCRIPTION
## Summary

- prepare the app release metadata for `0.9.5+0`
- roll the SDK submodule to the published SDK `0.6.0` release
- refresh the root lockfile to the SDK `0.6.0` package versions
- add top-level `v0.9.5` release notes while preserving the existing `v0.9.4` notes

## Validation

- `flutter pub get --offline`
- `dart pub get --enforce-lockfile -C sdk`
- `flutter analyze --no-fatal-warnings --no-fatal-infos`
- `flutter test test_units/main.dart`

Note: pub emitted non-fatal advisory decode warnings for hosted package advisories, but dependency resolution and validation commands exited successfully.