### PR TITLE
[codex] Restore wallet dependency validation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,6 +15,7 @@ analyzer:
   exclude:
     - "**/*.freezed.dart"
     - "**/*.g.dart"
+    - "sdk/**"
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -704,70 +704,77 @@ packages:
       path: "sdk/packages/komodo_cex_market_data"
       relative: true
     source: path
-    version: "0.1.0+1"
+    version: "0.1.0"
   komodo_coin_updates:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coin_updates"
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.0.0"
   komodo_coins:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coins"
       relative: true
     source: path
-    version: "0.3.2+1"
+    version: "0.3.2"
   komodo_defi_framework:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_framework"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.0"
   komodo_defi_local_auth:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_local_auth"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.0"
   komodo_defi_rpc_methods:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_rpc_methods"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.4.0"
   komodo_defi_sdk:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_sdk"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.5.0"
   komodo_defi_types:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_types"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.4.0"
+  komodo_legacy_wallet_migration:
+    dependency: "direct main"
+    description:
+      path: "sdk/packages/komodo_legacy_wallet_migration"
+      relative: true
+    source: path
+    version: "0.1.0"
   komodo_ui:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_ui"
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.3.1"
   komodo_wallet_build_transformer:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_wallet_build_transformer"
       relative: true
     source: path
-    version: "0.4.2"
+    version: "0.4.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -1277,6 +1284,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6+1"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1317,6 +1364,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1607,5 +1662,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.41.4"


### PR DESCRIPTION
## Summary

- Update `pubspec.lock` so it matches the pinned SDK submodule and the new `komodo_legacy_wallet_migration` path dependency.
- Exclude the `sdk/` submodule from the wallet root analyzer scope so `flutter analyze` validates wallet code instead of recursively analyzing standalone SDK products.

## Root Cause

The wallet `pubspec.yaml` now references `sdk/packages/komodo_legacy_wallet_migration`, but `pubspec.lock` had not been regenerated against the pinned SDK submodule. After initializing the submodule, `flutter pub get --enforce-lockfile` failed because the lockfile was stale. Once dependencies resolved, root analysis also walked into the SDK submodule and reported unrelated errors from nested SDK products.

## Validation

- `flutter pub get --enforce-lockfile`
- `dart pub get --enforce-lockfile -C sdk`
- `flutter analyze --no-fatal-warnings --no-fatal-infos`

Unit and integration tests were not run per repository guidance because they are currently failing.