### PR TITLE
chore: update KDF hash config and Firebase deploys

### DIFF
--- a/.github/actions/firebase-hosting-deploy/action.yml
+++ b/.github/actions/firebase-hosting-deploy/action.yml
@@ -1,0 +1,122 @@
+name: "Deploy Firebase Hosting"
+description: "Deploys Firebase Hosting with a pinned Firebase CLI and handles the current-active-version false positive"
+
+inputs:
+  firebaseServiceAccount:
+    description: "Firebase service account JSON"
+    required: true
+  channelId:
+    description: "Firebase Hosting channel ID. Use live for production deploys."
+    required: true
+  target:
+    description: "Firebase Hosting target or site"
+    required: false
+    default: ""
+  expires:
+    description: "Preview channel expiration"
+    required: false
+    default: "7d"
+  projectId:
+    description: "Firebase project ID"
+    required: true
+  firebaseToolsVersion:
+    description: "firebase-tools version to use"
+    required: false
+    default: "15.22.3"
+
+outputs:
+  details_url:
+    description: "Deployed Hosting URL"
+    value: ${{ steps.deploy.outputs.details_url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Deploy Firebase Hosting
+      id: deploy
+      shell: bash
+      env:
+        FIREBASE_SERVICE_ACCOUNT: ${{ inputs.firebaseServiceAccount }}
+        CHANNEL_ID: ${{ inputs.channelId }}
+        TARGET: ${{ inputs.target }}
+        EXPIRES: ${{ inputs.expires }}
+        PROJECT_ID: ${{ inputs.projectId }}
+        FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion }}
+      run: |
+        set -euo pipefail
+
+        credentials_file="$RUNNER_TEMP/firebase-service-account.json"
+        deploy_log="$RUNNER_TEMP/firebase-hosting-deploy.log"
+
+        printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$credentials_file"
+        chmod 600 "$credentials_file"
+
+        if ! jq empty "$credentials_file" >/dev/null; then
+          echo "Firebase service account secret is not valid JSON."
+          exit 1
+        fi
+
+        export GOOGLE_APPLICATION_CREDENTIALS="$credentials_file"
+        export FIREBASE_DEPLOY_AGENT="action-hosting-deploy"
+
+        if [ "$CHANNEL_ID" = "live" ]; then
+          if [ -n "$TARGET" ]; then
+            deploy_args=(deploy --only "hosting:$TARGET")
+            details_url="https://$TARGET.web.app/"
+          else
+            deploy_args=(deploy --only hosting)
+            details_url="https://$PROJECT_ID.web.app/"
+          fi
+          is_preview=false
+        else
+          safe_channel_id=$(printf '%s' "$CHANNEL_ID" | sed 's/[^A-Za-z0-9_.-]/_/g')
+          if [ "$safe_channel_id" != "$CHANNEL_ID" ]; then
+            echo "ChannelId \"$CHANNEL_ID\" contains unsupported characters. Using \"$safe_channel_id\" instead."
+          fi
+
+          deploy_args=(hosting:channel:deploy "$safe_channel_id")
+          if [ -n "$TARGET" ]; then
+            deploy_args+=(--only "$TARGET")
+          fi
+          if [ -n "$EXPIRES" ]; then
+            deploy_args+=(--expires "$EXPIRES")
+          fi
+          details_url=""
+          is_preview=true
+        fi
+
+        deploy_args+=(--project "$PROJECT_ID" --debug)
+
+        set +e
+        npx "firebase-tools@$FIREBASE_TOOLS_VERSION" "${deploy_args[@]}" 2>&1 | tee "$deploy_log"
+        deploy_status=${PIPESTATUS[0]}
+        set -e
+
+        if [ "$deploy_status" -ne 0 ]; then
+          if [ "$is_preview" = "true" ] \
+            && grep -q "supplied version" "$deploy_log" \
+            && grep -q "current active version" "$deploy_log"; then
+            echo "Firebase CLI reported the finalized preview version is already active; treating deploy as successful."
+          else
+            exit "$deploy_status"
+          fi
+        fi
+
+        if [ "$is_preview" = "true" ]; then
+          set +e
+          channel_output=$(npx "firebase-tools@$FIREBASE_TOOLS_VERSION" hosting:channel:open "$safe_channel_id" --site "$TARGET" --project "$PROJECT_ID" 2>&1)
+          open_status=$?
+          set -e
+
+          printf '%s\n' "$channel_output"
+
+          details_url=$(printf '%s\n%s\n' "$(cat "$deploy_log")" "$channel_output" \
+            | grep -Eo 'https://[^"[:space:]]+\.web\.app[^"[:space:]]*' \
+            | tail -n 1 || true)
+
+          if [ "$open_status" -ne 0 ] && [ -z "$details_url" ]; then
+            exit "$open_status"
+          fi
+        fi
+
+        echo "details_url=$details_url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -55,23 +55,19 @@ jobs:
       - name: Deploy Gleec Wallet Web dev preview (`dev` branch)
         id: deploy_dev
         if: github.ref == 'refs/heads/dev'
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        uses: ./.github/actions/firebase-hosting-deploy
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: live
           target: walletrc
           projectId: komodo-wallet-official
-          firebaseToolsVersion: 15.22.1
 
       - name: Deploy Gleec Wallet Web RC (`main` branch)
         id: deploy_rc
         if: github.ref == 'refs/heads/main'
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        uses: ./.github/actions/firebase-hosting-deploy
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: live
           target: prodrc
           projectId: komodo-wallet-official
-          firebaseToolsVersion: 15.22.1

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -62,6 +62,7 @@ jobs:
           channelId: live
           target: walletrc
           projectId: komodo-wallet-official
+          firebaseToolsVersion: 15.22.1
 
       - name: Deploy Gleec Wallet Web RC (`main` branch)
         id: deploy_rc
@@ -73,3 +74,4 @@ jobs:
           channelId: live
           target: prodrc
           projectId: komodo-wallet-official
+          firebaseToolsVersion: 15.22.1

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -72,6 +72,7 @@ jobs:
           target: walletrc
           expires: 7d
           projectId: komodo-wallet-official
+          firebaseToolsVersion: 15.22.1
 
       - name: Deploy Gleec Wallet Web dev preview (`dev` branch)
         id: deploy_dev
@@ -83,3 +84,4 @@ jobs:
           channelId: dev-preview
           target: walletrc
           projectId: komodo-wallet-official
+          firebaseToolsVersion: 15.22.1

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,6 +10,11 @@ on:
       - release/*
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch' }}
@@ -71,6 +76,50 @@ jobs:
           target: walletrc
           expires: 7d
           projectId: komodo-wallet-official
+
+      - name: Comment Firebase preview URL
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.details_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CHANNEL_ID: ${{ steps.get_preview_channel_id.outputs.preview_channel_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "Firebase deploy did not return a preview URL."
+            exit 1
+          fi
+
+          marker="<!-- firebase-hosting-preview-url -->"
+          body="$(cat <<EOF
+          $marker
+          ### Firebase Hosting Preview
+
+          Preview URL: $PREVIEW_URL
+
+          Channel: \`$CHANNEL_ID\`
+          Expires: 7d
+          Run: $RUN_URL
+          EOF
+          )"
+
+          comment_id="$(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- firebase-hosting-preview-url -->"))) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            jq -n --arg body "$body" '{body: $body}' \
+              | gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --input -
+          else
+            jq -n --arg body "$body" '{body: $body}' \
+              | gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --input -
+          fi
 
       - name: Deploy Gleec Wallet Web dev preview (`dev` branch)
         id: deploy_dev

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -64,24 +64,20 @@ jobs:
 
       - name: Deploy Gleec Wallet web feature preview (Expires in 7 days)
         id: deploy_preview
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        uses: ./.github/actions/firebase-hosting-deploy
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: "${{ steps.get_preview_channel_id.outputs.preview_channel_id }}"
           target: walletrc
           expires: 7d
           projectId: komodo-wallet-official
-          firebaseToolsVersion: 15.22.1
 
       - name: Deploy Gleec Wallet Web dev preview (`dev` branch)
         id: deploy_dev
         if: github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch'
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        uses: ./.github/actions/firebase-hosting-deploy
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: dev-preview
           target: walletrc
           projectId: komodo-wallet-official
-          firebaseToolsVersion: 15.22.1

--- a/.github/workflows/sdk-integration-preview.yml
+++ b/.github/workflows/sdk-integration-preview.yml
@@ -157,15 +157,13 @@ jobs:
 
       - name: Deploy SDK Integration Preview (Expires in 7 days)
         id: firebase_deploy
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        uses: ./.github/actions/firebase-hosting-deploy
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: "${{ steps.get_preview_channel_id.outputs.preview_channel_id }}"
           target: walletrc
           expires: 7d
           projectId: komodo-wallet-official
-          firebaseToolsVersion: 15.22.1
 
       - name: Display deployment information
         id: display_info

--- a/.github/workflows/sdk-integration-preview.yml
+++ b/.github/workflows/sdk-integration-preview.yml
@@ -165,6 +165,7 @@ jobs:
           target: walletrc
           expires: 7d
           projectId: komodo-wallet-official
+          firebaseToolsVersion: 15.22.1
 
       - name: Display deployment information
         id: display_info


### PR DESCRIPTION
## Summary

- Advance the `sdk` submodule pointer to `GLEECBTC/komodo-defi-sdk-flutter@b15a4f1a`.
- Pull in the SDK build config update from GLEECBTC/komodo-defi-sdk-flutter#356.
- Harden Firebase Hosting deploy workflows after the pre-existing web preview CI failure.

## SDK change included

- macOS KDF artifact matching now references universal KDF binary archives, not the static-library `libkdf` archive.
- macOS checksum now matches `kdf_d56a7bc-mac-universal.zip`.
- Bundled coins commit updated to `acc4c32b379fb8b9ea387a269d33b32bcf084079`.

## CI change included

- Replaced the FirebaseExtended Hosting deploy wrapper with a local composite deploy action.
- The local action uses `firebase-tools@15.22.3` to avoid the token-fetch issue seen with `15.22.1`.
- It preserves real deploy failures, while treating the known Firebase CLI `supplied version is the current active version` response as success after the preview version has already been finalized.
- The PR preview workflow no longer creates the extra Firebase `Deploy Preview` check that stayed red when the wrapper failed after deployment.

## Validation

- SDK build config JSON validation passed.
- SDK roll tool confirmed macOS selects `https://devbuilds.gleec.com/main/kdf_d56a7bc-mac-universal.zip` with checksum `d2896495fe813729d5e5612027cd0c8bf18f771d9c49552ee3f545df9bae868b`.
- SDK build transformer completed successfully on second run after expected first-run coin asset update.
- `flutter build macos --no-pub --release` completed successfully with code signing disabled.
- Workflow YAML parsing passed for the Firebase Hosting action/workflows.
- Embedded deploy Bash syntax check passed.
- Local simulated Firebase current-active-version path passed.
- GitHub Actions web preview `build_and_preview` passed on run `28367399754`.

## Notes

`flutter analyze` was run and still fails on existing analyzer debt unrelated to this submodule pointer update. Current remaining red checks are outside the web preview deploy path.