### PR TITLE
fix(ci): make Firebase Hosting preview deploy resilient to transient 409s

### DIFF
--- a/.github/actions/firebase-hosting-deploy/action.yml
+++ b/.github/actions/firebase-hosting-deploy/action.yml
@@ -87,20 +87,46 @@ runs:
 
         deploy_args+=(--project "$PROJECT_ID" --debug)
 
-        set +e
-        npx "firebase-tools@$FIREBASE_TOOLS_VERSION" "${deploy_args[@]}" 2>&1 | tee "$deploy_log"
-        deploy_status=${PIPESTATUS[0]}
-        set -e
+        # Firebase Hosting's REST API intermittently drops the connection
+        # ("premature close error") *after* the server has already actioned a
+        # request. firebase-tools then retries the call; for the non-idempotent
+        # channel create this comes back 409 ALREADY_EXISTS and fails the deploy
+        # even though the channel was created. Re-running hosting:channel:deploy
+        # is safe -- the existing channel is reused and the version is uploaded
+        # normally -- so retry these transient failures before giving up.
+        max_attempts=3
+        attempt=1
+        while :; do
+          set +e
+          npx "firebase-tools@$FIREBASE_TOOLS_VERSION" "${deploy_args[@]}" 2>&1 | tee "$deploy_log"
+          deploy_status=${PIPESTATUS[0]}
+          set -e
 
-        if [ "$deploy_status" -ne 0 ]; then
+          if [ "$deploy_status" -eq 0 ]; then
+            break
+          fi
+
+          # The finalized preview version already being the current active
+          # version is not an error -- the content is already live.
           if [ "$is_preview" = "true" ] \
             && grep -q "supplied version" "$deploy_log" \
             && grep -q "current active version" "$deploy_log"; then
             echo "Firebase CLI reported the finalized preview version is already active; treating deploy as successful."
-          else
-            exit "$deploy_status"
+            deploy_status=0
+            break
           fi
-        fi
+
+          # Retry the transient channel/connection failures described above.
+          if [ "$attempt" -lt "$max_attempts" ] \
+            && grep -qiE "already exists|premature close|ECONNRESET|socket hang up|EAI_AGAIN" "$deploy_log"; then
+            echo "Transient Firebase Hosting error on attempt ${attempt}/${max_attempts}; retrying in $((attempt * 10))s..."
+            sleep "$((attempt * 10))"
+            attempt=$((attempt + 1))
+            continue
+          fi
+
+          exit "$deploy_status"
+        done
 
         if [ "$is_preview" = "true" ]; then
           set +e

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,6 +15,12 @@ permissions:
   issues: write
   pull-requests: write
 
+# Cancel an in-flight preview build when a new commit is pushed to the same PR,
+# so two runs never race to create/update the same Firebase preview channel.
+concurrency:
+  group: firebase-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Problem

The Firebase **preview** deploy (`build_and_preview`) — and the `live` RC deploy, which shares the same action — has been failing intermittently with:

```
GET  .../sites/walletrc/channels/pull-<PR>-merge          → 404 NOT_FOUND
POST .../sites/walletrc/channels?channelId=pull-<PR>-merge → 409 ALREADY_EXISTS
Error: Channel ...channels/pull-<PR>-merge already exists.  → exit 1
```

### Root cause (not duplicate jobs)

There is only **one** preview run per PR, and at the start of the run the channel does **not** exist (`GET` → 404). The 409 is a **self-inflicted retry collision**: Firebase Hosting's REST API drops the connection (`premature close error`) *after* the server has already created the channel, so `firebase-tools` retries the **non-idempotent** channel-create POST — and the retry comes back `409 ALREADY_EXISTS`. The custom deploy action introduced in #3494 only tolerated the "current active version" false-positive, so it treated the 409 as fatal.

This explains the intermittency (only fails when a premature-close lands on the create POST).

## Fix

1. **Retry transient failures** in `.github/actions/firebase-hosting-deploy/action.yml` — retry `hosting:channel:deploy` up to 3× (10s/20s backoff) when the log shows `already exists`, `premature close`, `ECONNRESET`, `socket hang up`, or `EAI_AGAIN`. A re-run reuses the now-existing channel and uploads the version normally. The existing "current active version" tolerance is preserved; genuine errors still fail. (Also benefits the `live` RC deploy.)
2. **Concurrency guard** in `.github/workflows/firebase-hosting-pull-request.yml` — a new commit cancels a stale in-flight preview run (`cancel-in-progress`), keyed per PR, so two runs can never race on the same channel.

## Verification

- Both YAML files parse (ruby `YAML.load_file`).
- The embedded deploy script passes `bash -n` and is `shellcheck`-clean.

> Note: this only takes effect for CI runs **after** it merges to `dev`. Open release PR #3496's preview will go green once this lands (or on a re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)