### PR TITLE
fix(ci): treat "current active version" as success for live Firebase deploys

### DIFF
--- a/.github/actions/firebase-hosting-deploy/action.yml
+++ b/.github/actions/firebase-hosting-deploy/action.yml
@@ -106,12 +106,15 @@ runs:
             break
           fi
 
-          # The finalized preview version already being the current active
-          # version is not an error -- the content is already live.
-          if [ "$is_preview" = "true" ] \
-            && grep -q "supplied version" "$deploy_log" \
+          # The deployed version already being the current active version is
+          # not an error -- the served content is already up to date, so
+          # Firebase refuses to re-release the identical version with
+          # FAILED_PRECONDITION. This applies to live deploys (unchanged web
+          # build pushed to `dev`/`main`) as well as preview channels, so it is
+          # intentionally NOT gated on is_preview.
+          if grep -q "supplied version" "$deploy_log" \
             && grep -q "current active version" "$deploy_log"; then
-            echo "Firebase CLI reported the finalized preview version is already active; treating deploy as successful."
+            echo "Firebase CLI reported the deployed version is already the current active version; treating deploy as successful."
             deploy_status=0
             break
           fi


### PR DESCRIPTION
## Problem

The RC/staging web deploy (`firebase-hosting-merge.yml` → the shared `firebase-hosting-deploy` action, `channelId: live`, target `walletrc`) has failed on **every `dev` push today** (4/4), after deploying cleanly on Jun 11–12.

The untruncated job log shows the deploy uploads all files fine, then the final **release** call fails:

```
POST .../sites/walletrc/channels/live/releases → 400
"message": "Can't release to .../channels/live: supplied version … is the current active version.",
"status": "FAILED_PRECONDITION"
```

The web build is **byte-identical to what's already live**, so Firebase refuses to re-release the same version. That's a no-op, not a failure. It fits the history exactly: every failing push (`8fae93f` CI fix, `3a1c878` version+changelog, `d6cc042` KDF/CI, `fa7dd42` macOS signing) changed things that **don't alter the web bundle**; the last clean deploy (`1c30d4c`) was a real UI change.

## Root cause

The action **already tolerates** this exact case (`supplied version` + `current active version` → treat as success), but the check was **gated on `is_preview=true`** — so preview channels passed while `live`/staging deploys still failed.

## Fix

Drop the `is_preview` gate so the tolerance applies to `live` deploys too (one block in `.github/actions/firebase-hosting-deploy/action.yml`). Because that check runs *before* the transient-retry branch, it also stops the retry loop from pointlessly re-running the deterministic `FAILED_PRECONDITION` (the previous run retried it 3× because the log also contained transient "premature close" noise).

This is the staging-side companion to the preview-channel 409 fix already merged (#3497) — same shared action, different terminal symptom.

## Verification

- YAML parses (ruby `YAML.load_file`); embedded bash passes `bash -n` and is `shellcheck`-clean.
- Scoped strictly to this one change (8 insertions / 5 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)