### PR TITLE
fix(ci): pin Windows desktop build to windows-2022

### DIFF
--- a/.github/workflows/desktop-builds.yml
+++ b/.github/workflows/desktop-builds.yml
@@ -23,7 +23,14 @@ jobs:
             artifact_path: build/macos/Build/Products/Release/*.app
             artifact_name: komodo-wallet-macos
           - platform: windows
-            runner: windows-latest
+            # Pinned to windows-2022 (VS 2022 / CMake 3.x / MSVC 14.4x). The
+            # windows-latest image moved to VS 2026 (CMake 4.x, MSVC 14.51),
+            # which breaks the build: the bundled Firebase C++ SDK requires
+            # cmake_minimum_required < 3.5, and <experimental/coroutine> became
+            # a hard error. Revert to windows-latest once the firebase_* and
+            # local_auth_windows / flutter_inappwebview_windows plugins are
+            # upgraded to versions compatible with the VS 2026 toolchain.
+            runner: windows-2022
             build_command: flutter build windows --no-pub --release
             artifact_path: build/windows/x64/runner/Release/*
             artifact_name: komodo-wallet-windows


### PR DESCRIPTION
## Problem

The **Build Desktop (windows)** job fails at `flutter build windows --release`;
`linux` and `macos` pass, so only Windows turns the run red.

The `windows-latest` runner image moved to **Visual Studio 2026** (CMake 4.x,
MSVC 14.51), which breaks the Windows build in three successive ways:

1. **CMake configure error** — the bundled Firebase C++ SDK
   (`firebase_cpp_sdk_windows_12.7.0`, pinned by `firebase_core`) declares
   `cmake_minimum_required(VERSION < 3.5)`, and CMake 4.x removed that
   compatibility:
   ```
   CMake Error at .../extracted/firebase_cpp_sdk_windows/CMakeLists.txt:17
   (cmake_minimum_required): Compatibility with CMake < 3.5 has been removed.
   ```
2. **Compile error** — under MSVC 14.51 `<experimental/coroutine>` became a hard
   error `C2338` (STL1011), breaking `flutter_inappwebview_windows` and
   `local_auth_windows`.

## Fix

Pin the Windows job to **`windows-2022`** (VS 2022 / CMake 3.x / MSVC 14.4x).
This sidesteps all three issues at once and restores the previously-working
toolchain. Net change is a single line in the matrix (plus an explanatory
comment). linux / macos are untouched.

## Testing

- [x] CI: Build Desktop (windows) goes green
- [x] CI: linux / macos still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
