### PR TITLE
feat(wallet): expand default coin list

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -200,6 +200,11 @@ List<String> get enabledByDefaultCoins => [
   'GLEEC', // GLEEC ecosystem coin
   'KMD', // Komodo ecosystem coin
   'BTC-segwit', // Default Fiat Ramps coin
+  'ETH',
+  'TRX',
+  'USDT-ERC20',
+  'USDT-TRC20',
+  'USDC-ERC20',
 ];
 
 const String logsDbName = 'logs';


### PR DESCRIPTION
## Summary

- keep GLEEC, KMD, and SegWit BTC enabled by default
- add native ETH and TRX
- add USDT on Ethereum and TRON
- add USDC on Ethereum

## Why

Align the default wallet asset set with the requested eight chain-specific assets while preserving the existing config IDs and activation ordering.

## Impact

Newly registered or restored wallets will include the expanded default asset set. Existing wallets are unaffected.

## Validation

- `dart format lib/app_config/app_config.dart`
- `flutter analyze lib/app_config/app_config.dart` — no issues
- verified every configured asset ID exists in the pinned SDK coin metadata
- full `flutter analyze` was also attempted; it remains blocked by pre-existing findings in generated `build/ios/SourcePackages` sources and SDK-wide lint debt