### PR TITLE
fix(ci): make asset generation reliable

### DIFF
--- a/.github/actions/generate-assets/action.yml
+++ b/.github/actions/generate-assets/action.yml
@@ -158,14 +158,58 @@ runs:
           BUILD_CMD="$BUILD_CMD --dart-define=CI=true --dart-define=ANALYTICS_DISABLED=true"
         fi
 
-        # Run flutter build once to download coin icons and config files.
-        # The second build must re-register them in AssetManifest.bin, so we
-        # wipe the build directory afterwards -- but preserve native_assets
-        # which desktop builds generate and need to reuse.
-        echo ""
-        flutter pub get --enforce-lockfile > /dev/null 2>&1 || true
-        $BUILD_CMD > /dev/null 2>&1 || true
-        find build -mindepth 1 -maxdepth 1 ! -name 'native_assets' -exec rm -rf {} + 2>/dev/null || true
+        # Run flutter build once to download coin icons and config files. The
+        # transformer intentionally fails after updating these source assets so
+        # that the next build can register them in AssetManifest.bin.
+        #
+        # Asset downloads can fail transiently. Do not silently continue with
+        # an incomplete asset directory: retry the warm-up build and surface its
+        # output if the required assets are still missing.
+        required_generated_assets=(
+          "sdk/packages/komodo_defi_framework/assets/coin_icons/png/kmd.png"
+          "sdk/packages/komodo_defi_framework/assets/config/coins.json"
+          "sdk/packages/komodo_defi_framework/assets/config/coins_config.json"
+        )
+        warmup_log="$(mktemp)"
+        assets_ready=false
+
+        flutter pub get --enforce-lockfile
+
+        for attempt in 1 2 3; do
+          echo "Asset generation attempt $attempt of 3"
+
+          set +e
+          $BUILD_CMD > "$warmup_log" 2>&1
+          warmup_status=$?
+          set -e
+
+          assets_ready=true
+          for generated_asset in "${required_generated_assets[@]}"; do
+            if [ ! -s "$generated_asset" ]; then
+              echo "Missing generated asset: $generated_asset"
+              assets_ready=false
+            fi
+          done
+
+          # Force Flutter to rebuild the asset manifest on the next pass while
+          # preserving native_assets needed by desktop builds.
+          find build -mindepth 1 -maxdepth 1 ! -name 'native_assets' -exec rm -rf {} + 2>/dev/null || true
+
+          if [ "$assets_ready" = true ]; then
+            echo "Required coin assets generated successfully (warm-up exit status: $warmup_status)"
+            break
+          fi
+
+          echo "Asset generation attempt $attempt failed (exit status: $warmup_status)"
+          tail -n 200 "$warmup_log" || true
+        done
+
+        rm -f "$warmup_log"
+
+        if [ "$assets_ready" != true ]; then
+          echo "Error: Failed to generate required coin assets after 3 attempts"
+          exit 1
+        fi
 
         # Run flutter build and capture its output
         flutter pub get --enforce-lockfile

--- a/.github/actions/validate-build/action.yml
+++ b/.github/actions/validate-build/action.yml
@@ -32,21 +32,29 @@ runs:
           exit 1
         fi
 
-        # Decode the AssetManifest.bin and check for the coin icon presence
-        if [ ! -f build/web/assets/AssetManifest.bin ]; then
+        # Check that the generated KMD icon exists and was registered in the
+        # binary asset manifest. Redirect grep output instead of using `-q` so
+        # `pipefail` cannot turn a successful early match into a SIGPIPE error.
+        KMD_ICON="$SDK_KDF_ASSETS_DIR/assets/coin_icons/png/kmd.png"
+        ASSET_MANIFEST=build/web/assets/AssetManifest.bin
+
+        if [ ! -s "$KMD_ICON" ]; then
+          echo "Error: Generated KMD coin icon not found at $KMD_ICON"
+          echo "Available KMD icon paths:"
+          find build/web/assets -iname 'kmd.png' -print || true
+          exit 1
+        fi
+
+        if [ ! -f "$ASSET_MANIFEST" ]; then
           echo "Error: AssetManifest.bin file not found."
           exit 1
         fi
-        if ! strings build/web/assets/AssetManifest.bin | grep -qi "assets/coin_icons/png/kmd.png"; then
+
+        if ! strings "$ASSET_MANIFEST" | grep -Fi "assets/coin_icons/png/kmd.png" > /dev/null; then
           echo "Error: KMD coin icon not found in AssetManifest.bin"
-          echo "Output of case-invariant grep on build/web/assets/AssetManifest.bin"
-          strings build/web/assets/AssetManifest.bin | grep -i "assets/coin_icons/png/kmd.png"
-          echo "Listing kmd png files in assets/coin_icons/png"
-          ls -R build/web/assets | grep kmd.png
-          if ! strings build/web/assets/AssetManifest.bin | grep -qi "assets/coin_icons/png/kmd.png"; then
-            echo "Error: KMD coin icon not found in AssetManifest.bin"
-            exit 1
-          fi
+          echo "Coin-icon entries found in the manifest:"
+          strings "$ASSET_MANIFEST" | grep -Fi "assets/coin_icons/png/" | head -n 20 || true
+          exit 1
         fi
 
         # Check that $SDK_KDF_ASSETS_DIR/app_build/build_config.json is present, and is valid json


### PR DESCRIPTION
## Summary

- retry the asset-generation warm-up when required SDK coin assets are missing
- fail early with the warm-up output after repeated incomplete downloads
- validate the physical KMD icon and its asset-manifest registration with pipe-safe diagnostics

## Root cause

The preparatory Flutter build downloads the SDK coin assets and is expected to exit non-zero after updating them. The action redirected all of its output and ignored every failure, so a transient or incomplete download could be treated like the expected exit and the final web build could continue without `kmd.png`. The validator then failed, and its diagnostic pipeline exited early under `pipefail`.

## Impact

Firebase preview and release builds will no longer proceed with an incomplete generated asset directory. The final build still regenerates `AssetManifest.bin`, while desktop `native_assets` remain preserved.

## Validation

- YAML parsing passed for both composite actions
- embedded Bash syntax checks passed
- ShellCheck passed for the changed scripts (excluding pre-existing constructs)
- `git diff --check` passed
- Firebase preview run 29491368192 passed asset generation, build validation, and deployment: https://github.com/GLEECBTC/gleec-wallet/actions/runs/29491368192