### PR TITLE
docs(release): add SDK tag preflight

### DIFF
--- a/docs/BUILD_RELEASE.md
+++ b/docs/BUILD_RELEASE.md
@@ -12,6 +12,38 @@ Optionally, you can enable Firebase Analytics for the app. To do so, follow the 
 
 ⚠️ **IMPORTANT**: For all production builds, be sure to follow the security practices outlined in the [Build Security Advisory](./BUILD_SECURITY_ADVISORY.md). Always use `--enforce-lockfile` and `--no-pub` flags when building for production.
 
+## GitHub release preflight
+
+Run this check from a clean checkout of the exact app release commit before
+creating the app tag or GitHub release. It verifies that the SDK package version
+used by the pinned submodule has already been tagged in the upstream SDK
+repository.
+
+```bash
+git submodule update --init sdk
+
+SDK_VERSION="$(sed -n 's/^version: //p' sdk/packages/komodo_defi_sdk/pubspec.yaml)"
+SDK_TAG="komodo_defi_sdk-v${SDK_VERSION}"
+SDK_PIN="$(git rev-parse HEAD:sdk)"
+
+git -C sdk fetch origin "refs/tags/${SDK_TAG}:refs/tags/${SDK_TAG}"
+SDK_TAG_COMMIT="$(git -C sdk rev-list -n 1 "${SDK_TAG}")"
+TAGGED_SDK_VERSION="$(git -C sdk show "${SDK_TAG}:packages/komodo_defi_sdk/pubspec.yaml" | sed -n 's/^version: //p')"
+
+test "${TAGGED_SDK_VERSION}" = "${SDK_VERSION}"
+git -C sdk merge-base --is-ancestor "${SDK_TAG_COMMIT}" "${SDK_PIN}"
+```
+
+The remote tag fetch fails when the tag is missing. The version comparison
+fails when the tag names a commit with different package metadata, and the
+ancestry check fails when the app's pinned SDK commit does not contain the
+tagged release. The tagged commit may be an ancestor rather than the exact pin
+when the app includes reviewed post-release SDK fixes.
+
+Any failure blocks the app release. Complete the SDK release and create the
+correct upstream package tag first; do not create a placeholder app release or
+tag to bypass this check.
+
 ## Build for Web
 
 ### Standard build


### PR DESCRIPTION
## Summary

- add an SDK package-tag preflight to the app release guide
- verify the upstream tag exists, carries the expected package version, and is an ancestor of the app-pinned SDK commit
- block future app release preparation when the SDK tag is missing or mismatched

## Validation

- `git diff --check`
- preflight command block passes `bash -n`
- referenced documentation links resolve locally