### PR TITLE
fix(onboarding): make the backup gate's escape hatch actually escape

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -464,7 +464,7 @@
   "seedBackupGateGeneratedBody": "This wallet's recovery phrase was created for you and has never been shown. Anything sent to this address can only be recovered with those words \u2014 not with your password.",
   "seedBackupGateBody": "Save your recovery phrase before you receive funds. It is the only way to recover this wallet \u2014 your password will not do it.",
   "seedBackupGateBackUpNow": "Back up now",
-  "seedBackupGateImportInstead": "I meant to restore an existing wallet",
+  "seedBackupGateImportInstead": "Sign out and restore a different wallet",
   "seedBackupGateContinueAnyway": "Continue without backing up",
   "seedBackupGateShowAddress": "Show my address",
   "sendToAnalytics": "Send anonymous data to analytics",

--- a/lib/views/common/seed_backup_gate/seed_backup_gate.dart
+++ b/lib/views/common/seed_backup_gate/seed_backup_gate.dart
@@ -49,7 +49,8 @@ Future<bool> ensureSeedBackedUp(
   required SeedBackupGateReason reason,
   bool isTestCoin = false,
 }) async {
-  final wallet = context.read<AuthBloc>().state.currentUser?.wallet;
+  final authBloc = context.read<AuthBloc>();
+  final wallet = authBloc.state.currentUser?.wallet;
   if (!seedBackupGateRequired(wallet: wallet, isTestCoin: isTestCoin)) {
     return true;
   }
@@ -59,17 +60,29 @@ Future<bool> ensureSeedBackedUp(
     context: context,
     width: 420,
     barrierDismissible: false,
-    child: _SeedBackupGateDialog(wallet: wallet, reason: reason),
+    child: _SeedBackupGateDialog(
+      wallet: wallet,
+      reason: reason,
+      // Passed in rather than read off the dialog's own context: AppDialog
+      // pushes onto the root navigator, which is not guaranteed to sit under
+      // the same provider scope as the caller.
+      authBloc: authBloc,
+    ),
   );
 
   return proceed ?? false;
 }
 
 class _SeedBackupGateDialog extends StatefulWidget {
-  const _SeedBackupGateDialog({required this.wallet, required this.reason});
+  const _SeedBackupGateDialog({
+    required this.wallet,
+    required this.reason,
+    required this.authBloc,
+  });
 
   final Wallet wallet;
   final SeedBackupGateReason reason;
+  final AuthBloc authBloc;
 
   @override
   State<_SeedBackupGateDialog> createState() => _SeedBackupGateDialogState();
@@ -93,6 +106,19 @@ class _SeedBackupGateDialogState extends State<_SeedBackupGateDialog> {
     Navigator.of(context).pop(proceed);
   }
 
+  /// Declines the reveal *and* clears the way to actually restore.
+  ///
+  /// You cannot import a recovery phrase while signed into another wallet, so
+  /// stopping at "declined" left the user stranded on a coin page with no
+  /// address and no next step - the label promised an intent the button did
+  /// not deliver. Signing out is non-destructive (the wallet stays in the
+  /// list) and `MainLayout`'s auth listener routes back to the wallet page,
+  /// where Connect wallet opens the entry screen with the restore row on it.
+  void _restoreInstead() {
+    _close(false);
+    widget.authBloc.add(const AuthSignOutRequested());
+  }
+
   void _continueAnyway() {
     _acknowledgedThisSession.add(widget.wallet.name);
     _close(true);
@@ -114,7 +140,7 @@ class _SeedBackupGateDialogState extends State<_SeedBackupGateDialog> {
         isGenerated: seedWasGeneratedForUser(widget.wallet),
         reason: widget.reason,
         onBackUp: _startBackup,
-        onImportInstead: () => _close(false),
+        onImportInstead: _restoreInstead,
         onContinueAnyway: _continueAnyway,
       );
     }

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_common_buttons.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_common_buttons.dart
@@ -24,6 +24,8 @@ import 'package:web_dex/shared/constants.dart';
 import 'package:web_dex/shared/gasless/tron_gasless_policy.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
 import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/seed_backup/seed_backup_policy.dart';
+import 'package:web_dex/views/common/seed_backup_gate/seed_backup_gate.dart';
 import 'package:web_dex/views/bitrefill/bitrefill_button.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/coin_addresses.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/contract_address_button.dart';
@@ -482,6 +484,16 @@ class CoinDetailsReceiveButton extends StatelessWidget {
   final BuildContext context;
 
   Future<void> _handleReceive(BuildContext context) async {
+    // Warn before the address picker rather than after a selection. The gate
+    // inside showPubkeyReceiveDialog still backs up its other call sites, and
+    // the per-session acknowledgement means asking here does not double-prompt.
+    final mayReveal = await ensureSeedBackedUp(
+      context,
+      reason: SeedBackupGateReason.receiveAddress,
+      isTestCoin: coin.isTestCoin,
+    );
+    if (!mayReveal || !context.mounted) return;
+
     // Get coin addresses bloc from the parent widget
     final addressesBloc = context.read<CoinAddressesBloc>();
     final addressesState = addressesBloc.state;

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -97,9 +97,14 @@ class _WalletCreationState extends State<WalletCreation> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  widget.action == WalletsManagerAction.create
-                      ? LocaleKeys.walletCreationTitle.tr()
-                      : LocaleKeys.walletImportTitle.tr(),
+                  // Keyed on `import` rather than `create` so the neutral
+                  // `none` state - which this widget also renders, including
+                  // for the frame where the dialog is dismissing after a
+                  // successful create - reads as "Create wallet" instead of
+                  // briefly flipping to "Import wallet".
+                  widget.action == WalletsManagerAction.import
+                      ? LocaleKeys.walletImportTitle.tr()
+                      : LocaleKeys.walletCreationTitle.tr(),
                   style: Theme.of(
                     context,
                   ).textTheme.titleLarge?.copyWith(fontSize: 18),

--- a/test_units/main.dart
+++ b/test_units/main.dart
@@ -79,6 +79,7 @@ import 'tests/wallet/coins_bloc_balance_emit_test.dart';
 import 'tests/services/legal_acceptance_test.dart';
 import 'tests/services/storage_persistence_gate_test.dart';
 import 'tests/wallet/seed_backup_policy_test.dart';
+import 'views/common/seed_backup_gate_test.dart';
 import 'tests/analytics/onboarding_funnel_test.dart';
 import 'tests/analytics/transaction_event_privacy_test.dart';
 import 'tests/bitrefill/bitrefill_refund_url_test.dart';
@@ -229,6 +230,7 @@ void main() {
   testLegalAcceptance();
   testStoragePersistenceGate();
   testSeedBackupPolicy();
+  testSeedBackupGate();
   testOnboardingFunnel();
   testTransactionEventPrivacy();
   testBitrefillRefundUrl();

--- a/test_units/views/common/seed_backup_gate_test.dart
+++ b/test_units/views/common/seed_backup_gate_test.dart
@@ -1,0 +1,223 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
+import 'package:web_dex/shared/seed_backup/seed_backup_policy.dart';
+import 'package:web_dex/views/common/seed_backup_gate/seed_backup_gate.dart';
+
+class _EmptyAssetLoader extends AssetLoader {
+  const _EmptyAssetLoader();
+
+  @override
+  Future<Map<String, dynamic>> load(String path, Locale locale) async => {};
+}
+
+class _FakeAuthBloc extends Cubit<AuthBlocState> implements AuthBloc {
+  _FakeAuthBloc(super.initialState);
+
+  final List<AuthBlocEvent> addedEvents = [];
+
+  @override
+  void add(AuthBlocEvent event) => addedEvents.add(event);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+KdfUser _user({required bool hasBackup, String provenance = 'generated'}) =>
+    KdfUser(
+      walletId: WalletId.fromName(
+        'gate-wallet',
+        const AuthOptions(derivationMethod: DerivationMethod.hdWallet),
+      ),
+      isBip39Seed: true,
+      metadata: {
+        'type': 'hdwallet',
+        'has_backup': hasBackup,
+        'wallet_provenance': provenance,
+      },
+    );
+
+/// Pumps a button that runs the gate and records what it returned.
+Future<List<bool>> _pumpGate(
+  WidgetTester tester, {
+  required _FakeAuthBloc authBloc,
+}) async {
+  final results = <bool>[];
+
+  await tester.pumpWidget(
+    EasyLocalization(
+      supportedLocales: const [Locale('en')],
+      fallbackLocale: const Locale('en'),
+      startLocale: const Locale('en'),
+      saveLocale: false,
+      path: 'assets/translations',
+      assetLoader: const _EmptyAssetLoader(),
+      child: Builder(
+        builder: (context) => MaterialApp(
+          locale: context.locale,
+          supportedLocales: context.supportedLocales,
+          localizationsDelegates: context.localizationDelegates,
+          home: BlocProvider<AuthBloc>.value(
+            value: authBloc,
+            child: Scaffold(
+              body: Builder(
+                builder: (inner) => ElevatedButton(
+                  onPressed: () async {
+                    results.add(
+                      await ensureSeedBackedUp(
+                        inner,
+                        reason: SeedBackupGateReason.receiveAddress,
+                      ),
+                    );
+                  },
+                  child: const Text('reveal'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  return results;
+}
+
+void testSeedBackupGate() {
+  group('seed backup gate', () {
+    setUp(resetSeedBackupAcknowledgements);
+    tearDown(resetSeedBackupAcknowledgements);
+
+    testWidgets('a backed-up wallet is revealed without any prompt', (
+      tester,
+    ) async {
+      final authBloc = _FakeAuthBloc(
+        AuthBlocState.loggedIn(_user(hasBackup: true)),
+      );
+      addTearDown(authBloc.close);
+
+      final results = await _pumpGate(tester, authBloc: authBloc);
+      await tester.tap(find.text('reveal'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('seed-backup-gate-notice')), findsNothing);
+      expect(results, [true]);
+    });
+
+    testWidgets('an un-backed-up wallet is stopped by the notice', (
+      tester,
+    ) async {
+      final authBloc = _FakeAuthBloc(
+        AuthBlocState.loggedIn(_user(hasBackup: false)),
+      );
+      addTearDown(authBloc.close);
+
+      await _pumpGate(tester, authBloc: authBloc);
+      await tester.tap(find.text('reveal'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('seed-backup-gate-notice')), findsOneWidget);
+    });
+
+    testWidgets(
+      'continue-anyway reveals, and does not re-prompt this session',
+      (tester) async {
+        final authBloc = _FakeAuthBloc(
+          AuthBlocState.loggedIn(_user(hasBackup: false)),
+        );
+        addTearDown(authBloc.close);
+
+        final results = await _pumpGate(tester, authBloc: authBloc);
+
+        await tester.tap(find.text('reveal'));
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const Key('seed-backup-gate-continue-button')),
+        );
+        await tester.pumpAndSettle();
+        expect(results, [true]);
+
+        // Second reveal in the same session must go straight through.
+        await tester.tap(find.text('reveal'));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('seed-backup-gate-notice')), findsNothing);
+        expect(results, [true, true]);
+      },
+    );
+
+    testWidgets('acknowledging never marks the seed as backed up', (
+      tester,
+    ) async {
+      final authBloc = _FakeAuthBloc(
+        AuthBlocState.loggedIn(_user(hasBackup: false)),
+      );
+      addTearDown(authBloc.close);
+
+      await _pumpGate(tester, authBloc: authBloc);
+      await tester.tap(find.text('reveal'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('seed-backup-gate-continue-button')),
+      );
+      await tester.pumpAndSettle();
+
+      // The banner, the menu indicator and the settings label all read
+      // has_backup as proof the user holds their words. Acknowledging is not
+      // that proof, so it must not dispatch a backup confirmation.
+      expect(
+        authBloc.addedEvents.whereType<AuthSeedBackupConfirmed>(),
+        isEmpty,
+      );
+    });
+
+    testWidgets('restore-instead declines the reveal and signs out', (
+      tester,
+    ) async {
+      final authBloc = _FakeAuthBloc(
+        AuthBlocState.loggedIn(_user(hasBackup: false)),
+      );
+      addTearDown(authBloc.close);
+
+      final results = await _pumpGate(tester, authBloc: authBloc);
+      await tester.tap(find.text('reveal'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('seed-backup-gate-import-instead-button')),
+      );
+      await tester.pumpAndSettle();
+
+      // Declines the address...
+      expect(results, [false]);
+      // ...and clears the way to actually restore, which is impossible while
+      // signed into another wallet.
+      expect(
+        authBloc.addedEvents.whereType<AuthSignOutRequested>(),
+        hasLength(1),
+      );
+    });
+
+    testWidgets('an imported wallet gets no restore-instead escape hatch', (
+      tester,
+    ) async {
+      // That branch exists to catch someone who meant to restore and was
+      // routed into creating. It makes no sense once they did import.
+      final authBloc = _FakeAuthBloc(
+        AuthBlocState.loggedIn(_user(hasBackup: false, provenance: 'imported')),
+      );
+      addTearDown(authBloc.close);
+
+      await _pumpGate(tester, authBloc: authBloc);
+      await tester.tap(find.text('reveal'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('seed-backup-gate-notice')), findsOneWidget);
+      expect(
+        find.byKey(const Key('seed-backup-gate-import-instead-button')),
+        findsNothing,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Three defects found by driving the deployed preview build by hand, stacked on #3509.

## 1. The escape hatch went nowhere

"I meant to restore an existing wallet" correctly declined the address reveal — and then did nothing else. You cannot import a recovery phrase while signed into another wallet, so the user was left on a coin page with no address and no next step. The label promised an intent the button did not deliver.

It now signs out and relies on `MainLayout`'s existing auth listener to route back to the wallet page, where **Connect wallet** opens the entry screen with the restore row on it. Sign-out is non-destructive — the wallet stays in the list. Relabelled to **"Sign out and restore a different wallet"** so the copy matches the action.

**Latent bug found while fixing it:** the gate read `AuthBloc` off the *dialog's* context. `AppDialog` pushes onto the root navigator, which is not guaranteed to sit under the same provider scope as the caller — it happens to work in production only because `AuthBloc` is provided above `MaterialApp.router`. The new widget test caught it as a `ProviderNotFoundException`. The bloc is now captured from the caller's context and passed in.

## 2. The gate fired after the address picker

Tapping Receive opened `showAddressSearch` first — which lists a **truncated** address — and only warned once one was selected. Not a funding leak, but the wrong order.

Moved ahead of the picker in `_handleReceive`. The gate inside `showPubkeyReceiveDialog` stays as the backstop for its other two call sites, and the per-session acknowledgement means asking earlier does not double-prompt.

## 3. Create-form title flipped on dismiss

The title read "Import wallet" for a frame while the dialog dismissed after a successful create, because the neutral `none` action fell into the import branch. Keyed on `import` instead.

## Tests

New `seed_backup_gate_test` covering all six branches — including that **acknowledging never dispatches a backup confirmation**. The global banner, the desktop menu indicator and the settings label all read `has_backup` as proof the user holds their words; acknowledging is not that proof, and that boundary is now pinned.

**676 unit tests pass, 0 analyzer errors.** No `pubspec.lock` change — regenerating it off a non-pinned Flutter breaks `--enforce-lockfile`.

## Not covered

Findings came from web QA on the preview build. Android untested here; iOS remains unsigned and untestable this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)