### PR TITLE
fix(ci): stop treating the hosting deploy target as a site ID, and rename it to `web`

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,14 +5,14 @@
   "targets": {
     "komodo-wallet-official": {
       "hosting": {
-        "walletrc": [
+        "web": [
           "walletrc"
         ]
       }
     },
     "komodo-wallet-preview": {
       "hosting": {
-        "walletrc": [
+        "web": [
           "komodo-wallet-preview"
         ]
       }

--- a/.github/actions/firebase-hosting-deploy/action.yml
+++ b/.github/actions/firebase-hosting-deploy/action.yml
@@ -42,6 +42,7 @@ runs:
         EXPIRES: ${{ inputs.expires }}
         PROJECT_ID: ${{ inputs.projectId }}
         FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion }}
+        URL_READER: ${{ github.action_path }}/../../scripts/hosting_deploy_url.sh
       run: |
         set -euo pipefail
 
@@ -62,10 +63,8 @@ runs:
         if [ "$CHANNEL_ID" = "live" ]; then
           if [ -n "$TARGET" ]; then
             deploy_args=(deploy --only "hosting:$TARGET")
-            details_url="https://$TARGET.web.app/"
           else
             deploy_args=(deploy --only hosting)
-            details_url="https://$PROJECT_ID.web.app/"
           fi
           is_preview=false
         else
@@ -81,7 +80,6 @@ runs:
           if [ -n "$EXPIRES" ]; then
             deploy_args+=(--expires "$EXPIRES")
           fi
-          details_url=""
           is_preview=true
         fi
 
@@ -131,20 +129,17 @@ runs:
           exit "$deploy_status"
         done
 
-        if [ "$is_preview" = "true" ]; then
-          set +e
-          channel_output=$(npx "firebase-tools@$FIREBASE_TOOLS_VERSION" hosting:channel:open "$safe_channel_id" --site "$TARGET" --project "$PROJECT_ID" 2>&1)
-          open_status=$?
-          set -e
-
-          printf '%s\n' "$channel_output"
-
-          details_url=$(printf '%s\n%s\n' "$(cat "$deploy_log")" "$channel_output" \
-            | grep -Eo 'https://[^"[:space:]]+\.web\.app[^"[:space:]]*' \
-            | tail -n 1 || true)
-
-          if [ "$open_status" -ne 0 ] && [ -z "$details_url" ]; then
-            exit "$open_status"
+        # Read the deployed URL out of what the CLI actually did, rather than
+        # building it from the target name -- a deploy target is not a site ID.
+        # See the script for why, and .github/scripts/test_hosting_deploy_url.sh
+        # for the output formats it depends on.
+        if ! details_url=$("$URL_READER" "$deploy_log"); then
+          echo "Deploy succeeded but no URL was found in the Firebase CLI output."
+          details_url=""
+          if [ "$is_preview" = "true" ]; then
+            # The preview URL is consumed downstream to comment on the PR, so a
+            # missing one is a failure rather than a cosmetic gap.
+            exit 1
           fi
         fi
 

--- a/.github/scripts/hosting_deploy_url.sh
+++ b/.github/scripts/hosting_deploy_url.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Print the URL a Firebase Hosting deploy actually published, read out of the
+# CLI's own output.
+#
+#   hosting_deploy_url.sh <path-to-firebase-cli-log>
+#
+# Exits 0 and prints the URL, or exits 1 and prints nothing.
+#
+# Why this is not simply "https://$TARGET.web.app":
+#
+# A deploy target is not a site ID. `.firebaserc` maps one target to a
+# different site in each project, which is the whole reason the target exists,
+# so a URL built from the target name is only right in whichever project
+# happens to have a site of the same name. The CLI knows the resolved site and
+# prints it, so ask it rather than guessing:
+#
+#   live deploy     "Hosting URL: https://<site>.web.app"
+#                   firebase-tools lib/deploy/index.js
+#   preview channel "hosting:channel: Channel URL (<site>): https://<...>.web.app [expires ...]"
+#                   firebase-tools lib/commands/hosting-channel-deploy.js
+#
+# Both lines are emitted unconditionally on success, so an empty result here
+# means the deploy did not publish anything.
+
+set -uo pipefail
+
+log_path="${1:-}"
+if [ -z "$log_path" ]; then
+  echo "usage: $0 <path-to-firebase-cli-log>" >&2
+  exit 2
+fi
+if [ ! -f "$log_path" ]; then
+  echo "no such log file: $log_path" >&2
+  exit 2
+fi
+
+# The CLI colourises these lines when it thinks it has a terminal, and the
+# escapes land in the middle of the URL's own line, so strip them first.
+url=$(sed $'s/\033\[[0-9;]*m//g' "$log_path" \
+  | sed -n \
+      -e 's/.*Hosting URL: *\(https:\/\/[^[:space:]]*\).*/\1/p' \
+      -e 's/.*Channel URL[^:]*: *\(https:\/\/[^[:space:]]*\).*/\1/p' \
+  | tail -n 1)
+
+if [ -z "$url" ]; then
+  exit 1
+fi
+
+printf '%s\n' "$url"

--- a/.github/scripts/test_hosting_deploy_url.sh
+++ b/.github/scripts/test_hosting_deploy_url.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Tests for hosting_deploy_url.sh.
+#
+# The thing under test is a regex over another tool's human-readable output, so
+# it can stop matching without anything failing loudly: `details_url` would
+# quietly go empty and the PR-comment step would be the first to notice. These
+# fixtures pin the two lines the Firebase CLI is relied on to print.
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly script_dir
+readonly subject="$script_dir/hosting_deploy_url.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+# expect <name> <expected-url-or-empty> <log lines...>
+expect() {
+  local name="$1" expected="$2"
+  shift 2
+
+  local log="$work/log.txt"
+  printf '%s\n' "$@" > "$log"
+
+  local actual status
+  actual=$("$subject" "$log" 2>/dev/null)
+  status=$?
+
+  if [ -z "$expected" ]; then
+    if [ "$status" -eq 1 ] && [ -z "$actual" ]; then
+      printf '  ok    %s\n' "$name"
+    else
+      printf '  FAIL  %s: expected no URL and exit 1, got %q and exit %d\n' \
+        "$name" "$actual" "$status" >&2
+      failures=$((failures + 1))
+    fi
+    return
+  fi
+
+  if [ "$status" -eq 0 ] && [ "$actual" = "$expected" ]; then
+    printf '  ok    %s\n' "$name"
+  else
+    printf '  FAIL  %s: expected %q (exit 0), got %q (exit %d)\n' \
+      "$name" "$expected" "$actual" "$status" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "hosting_deploy_url.sh"
+
+expect 'live deploy reports the resolved site' \
+  'https://walletrc.web.app' \
+  '=== Deploy complete!' \
+  'Project Console: https://console.firebase.google.com/project/komodo-wallet-official/overview' \
+  'Hosting URL: https://walletrc.web.app'
+
+# The case the old "https://$TARGET.web.app" construction got wrong: the same
+# target deployed against a different project resolves to a different site.
+expect 'live deploy to another project reports that project'"'"'s site' \
+  'https://gleec-wallet-official.web.app' \
+  'Project Console: https://console.firebase.google.com/project/gleec-wallet-official/overview' \
+  'Hosting URL: https://gleec-wallet-official.web.app'
+
+expect 'preview channel URL' \
+  'https://walletrc--pull-3514-merge-8l82t6ov.web.app' \
+  'i  hosting: uploading new files [12/12] complete' \
+  '+  hosting:channel: Channel URL (walletrc): https://walletrc--pull-3514-merge-8l82t6ov.web.app [expires 2026-09-03] [version fingerprint abc]'
+
+expect 'colourised output' \
+  'https://walletrc--pr-1.web.app' \
+  "$(printf '\033[32m+\033[39m  hosting:channel: Channel URL (\033[1mwalletrc\033[22m): https://walletrc--pr-1.web.app [expires 2026-09-03]')"
+
+# --debug is passed on every deploy, so the log is mostly API chatter.
+expect 'ignores --debug chatter and the console link' \
+  'https://walletrc.web.app' \
+  '[debug] [2026-08-27T15:13:00.000Z] >>> [apiv2][query] GET https://firebasehosting.googleapis.com/v1beta1/projects/x/sites' \
+  '[debug] Deploy target web resolved to site walletrc' \
+  'Project Console: https://console.firebase.google.com/project/x/overview' \
+  'Hosting URL: https://walletrc.web.app'
+
+expect 'a log with no published URL yields nothing' \
+  '' \
+  'i  deploying hosting' \
+  'Error: HTTP Error: 404, Requested entity was not found.'
+
+expect 'a custom domain in the log does not win over the deploy URL' \
+  'https://walletrc.web.app' \
+  'i  hosting: see https://dex.gleec.com for the production site' \
+  'Hosting URL: https://walletrc.web.app'
+
+if [ "$failures" -eq 0 ]; then
+  echo "PASS"
+  exit 0
+fi
+echo "FAIL - ${failures} case(s)" >&2
+exit 1

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: live
-          target: walletrc
+          target: web
           projectId: komodo-wallet-official
 
       - name: Deploy Gleec Wallet Web RC (`main` branch)

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: "${{ steps.get_preview_channel_id.outputs.preview_channel_id }}"
-          target: walletrc
+          target: web
           expires: 7d
           projectId: komodo-wallet-official
 
@@ -153,5 +153,5 @@ jobs:
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: dev-preview
-          target: walletrc
+          target: web
           projectId: komodo-wallet-official

--- a/.github/workflows/sdk-integration-preview.yml
+++ b/.github/workflows/sdk-integration-preview.yml
@@ -359,7 +359,7 @@ jobs:
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOMODO_WALLET_OFFICIAL }}"
           channelId: "${{ steps.get_preview_channel_id.outputs.preview_channel_id }}"
-          target: walletrc
+          target: web
           expires: 7d
           projectId: komodo-wallet-official
 

--- a/.github/workflows/validate-code-guidelines.yml
+++ b/.github/workflows/validate-code-guidelines.yml
@@ -38,6 +38,13 @@ jobs:
             dart pub get -C sdk
           fi
 
+      # The Firebase deploy action reads its published URL out of the CLI's
+      # own output. That is a regex over another tool's text, so it can stop
+      # matching silently; these fixtures are what notice.
+      - name: Test the hosting deploy URL reader
+        id: test_hosting_deploy_url
+        run: .github/scripts/test_hosting_deploy_url.sh
+
       - name: Validate dart code
         id: validate_dart
         run: |

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,21 @@
 {
+  // One hosting config, deployed to a different site depending on which
+  // Firebase project it is deployed against. `.firebaserc` maps the `web`
+  // deploy target per project:
+  //
+  //   komodo-wallet-official -> site walletrc              (CI, push to `dev`)
+  //   komodo-wallet-preview  -> site komodo-wallet-preview (local default)
+  //
+  //   firebase deploy --only hosting:web --project <project>
+  //
+  // `web` names the ROLE ("the wallet web app site for this project"), not a
+  // site. Do not name it after any one site: the target is shared across
+  // projects, so a site-shaped name is wrong everywhere except one place.
+  // `--project` is what selects the site, so always pass it -- a bare
+  // `firebase deploy` uses `.firebaserc`'s default, which is the preview
+  // project on purpose.
   "hosting": {
-    "target": "walletrc",
+    "target": "web",
     "public": "build/web",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     // "headers": [


### PR DESCRIPTION
## Summary

`walletrc` was one word doing two jobs — the name of a Firebase **site**, and the name of a **deploy target**. PR #3500 made them diverge: `.firebaserc` now maps that single target to a different site in each project, so `walletrc` already resolves to `komodo-wallet-preview` when deployed against the preview project. A token that says "release candidate" naming something that isn't one is the kind of thing that gets misread at 2am.

Renaming it was blocked, because two places in the deploy action read the target *as* a site ID. This PR removes that coupling first, then renames.

## The conflation

- **`details_url="https://$TARGET.web.app/"`** on the live path.
- **`hosting:channel:open --site "$TARGET"`** on the preview path. `--site` takes a raw site ID: that command contains no target-resolution machinery at all — grep firebase-tools 15.22.3 `lib/commands/hosting-channel-open.js` for `hosting/config`, `requireTarget` or `resolveTargets` and you get **zero hits**; `options.site` goes straight into `getChannel()`.

Dropping the flag is not a fix either — `requireHostingSite` falls back to `getDefaultHostingSite`, i.e. the **project's** default site. Here that is `komodo-wallet-official` (serving 0.9.3), not `walletrc` (serving 0.9.7). Different sites, same project.

Both work today purely because the two names coincide in the one project previews run against.

## The fix: ask the CLI what it actually did

It prints the resolved site itself, unconditionally on success:

| | line | source |
|---|---|---|
| live | `Hosting URL: https://<site>.web.app` | `lib/deploy/index.js` |
| preview | `hosting:channel: Channel URL (<site>): https://…` | `lib/commands/hosting-channel-deploy.js` |

`.github/scripts/hosting_deploy_url.sh` reads them. It is a regex over another tool's human-readable output, so it can stop matching silently — `test_hosting_deploy_url.sh` pins the formats (including ANSI colouring, `--debug` chatter, and the empty case), and `validate-code-guidelines` runs it on every PR. This follows the existing `.github/scripts/<x>.sh` + `test_<x>.sh` convention.

The `hosting:channel:open` call is **removed**. It was only ever a second source for a URL the deploy log already contains, and in CI it also tries to open a browser on the runner.

## The rename

Target `walletrc` → **`web`**: a role — *"the wallet web app site for this project"* — not a site. **Site names are untouched**; `walletrc` is still `walletrc`.

`.firebaserc` (2 blocks), `firebase.json` (1 line), 4 workflow call sites.

## Verification

Ran firebase-tools 15.22.3's **own resolver** (`lib/hosting/config.js`) against the real `firebase.json` and `.firebaserc`. Every deploy path lands on exactly the site it did before:

```
--only hosting:web --project komodo-wallet-official  -> site walletrc
--only hosting:web --project komodo-wallet-preview   -> site komodo-wallet-preview
bare deploy (default project)                        -> site komodo-wallet-preview
--only hosting:walletrc (stale reference)            -> aborts, deploys nothing
```

Then executed the action's own shell against a stubbed CLI: live deploy, preview channel, **a live deploy against a different project** (the case `https://$TARGET.web.app` got wrong — it would have said `https://web.web.app/`), and the no-URL failure path (preview exits 1; the PR-comment step already treats an empty URL as fatal).

## Interaction with #3514

[#3514](https://github.com/GLEECBTC/gleec-wallet/pull/3514) also touches `.firebaserc` and `firebase.json` — it adds a third project block so production (`dex.gleec.com`) can be deployed from the same config. The two will conflict on those files whichever order they merge in; the resolution is mechanical (rename the third block's target to `web`, or add it under `web`). I'll handle it on whichever lands second. #3514 also adds a unit test asserting `firebase.json`'s target matches the `.firebaserc` mapping, which closes the one drift risk this PR leaves open — until then a mismatch fails loudly at the next `dev` deploy rather than silently.

## Not in this PR

The `main` → `prodrc` step in `firebase-hosting-merge.yml` is still dead — `prodrc` is neither in `firebase.json` nor mapped in `.firebaserc`, and the workflow only triggers on `dev` anyway. It has the same target/site conflation, so removing or repointing it belongs with that cleanup rather than here.
